### PR TITLE
topページにお知らせmodalを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 ####### 普段の開発向け
 .PHONY: run
 run:
-	cd t0016Go/cmd/t0016Go && go run main.go
+	cd t0016Go/cmd && go run main.go
 
 .PHONY: db-be
 db-be:
-	docker compose up db
+	docker compose up -d db
 	make run
 
 .PHONY: fe

--- a/t0016Next/myapp/src/features/notice/notice.tsx
+++ b/t0016Next/myapp/src/features/notice/notice.tsx
@@ -25,21 +25,23 @@ export const TopPageNotice = () => {
       </div>
 
       {isDisplay && (
-        <div className="absolute flex items-center justify-center z-10 top-0 left-0 h-full w-full">
+        <div className="fixed inset-0 flex items-center justify-center z-10">
           <div
             className="h-full w-full bg-black opacity-50"
             onClick={() => setIsDisplay(false)}
           />
 
           <div
-            className="absolute z-40 flex flex-col top-[150px] items-center md:max-w-3xl w-[90%] p-2 pt-5
+            className="absolute z-30 md:top-[150px] flex flex-col items-center md:max-w-3xl w-[90%] p-2 pt-5
             bg-[#B7A692] rounded-2xl shadow-lg shadow-black"
           >
             <div className="ml-4 text-black">
               <div className="font-bold">お知らせ全件</div>
-              {NoticeItems.map((item) => (
-                <li key={item.id}>{item.content}</li>
-              ))}
+              <div className="overflow-y-auto scroll  max-h-full h-96 p-1">
+                {NoticeItems.map((item) => (
+                  <li key={item.id}>{item.content}</li>
+                ))}
+              </div>
             </div>
             <div
               className={`${ToClickTW.regular} font-normal w-13`}

--- a/t0016Next/myapp/src/features/notice/notice.tsx
+++ b/t0016Next/myapp/src/features/notice/notice.tsx
@@ -22,7 +22,6 @@ export const TopPageNotice = () => {
         <li>{NoticeItems[0].content}</li>
         <li>{NoticeItems[1].content}</li>
         <li>{NoticeItems[2].content}</li>
-        {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
       </div>
 
       {isDisplay && (
@@ -41,7 +40,6 @@ export const TopPageNotice = () => {
               {NoticeItems.map((item) => (
                 <li key={item.id}>{item.content}</li>
               ))}
-              {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
             </div>
             <div
               className={`${ToClickTW.regular} font-normal w-13`}

--- a/t0016Next/myapp/src/features/notice/notice.tsx
+++ b/t0016Next/myapp/src/features/notice/notice.tsx
@@ -6,40 +6,69 @@ export const TopPageNotice = () => {
   const [isDisplay, setIsDisplay] = useState(false);
 
   return (
-    <>
-      {isDisplay && (
-        <div
-          className="absolute z-40 top-[-150px] h-52 w-[86%] md:w-96  bg-[#B7A692]
-            p-2 pt-5 rounded-2xl shadow-lg shadow-black"
-        >
-          <div className="flex flex-col item-center md:text-2xl font-bold">
-            <span className="mx-auto">登録完了しました。</span>
-            <span className="flex mx-auto">
-              ページ内のリストを更新しますか？
-            </span>
+    <div className="flex flex-col items-center max-w-[1000px] m-auto mt-2">
+      <div>
+        <div className="flex items-end">
+          <div className="items-start">〇お知らせ</div>
+          <div
+            className="flex text-xs justify-center rounded-md h-[15px] w-[15px] m-0.5 bg-[#776D5C] hover:opacity-70 cursor-pointer"
+            onClick={() => setIsDisplay(true)}
+          >
+            ？
           </div>
-          <div className="flex flex-col md:flex-row md:text-xl mt-2 md:mt-6">
-            <button
-              type="button"
-              onClick={() => setIsDisplay(false)}
-              className={`${ToClickTW.boldChoice} p-2 mx-auto mt-4 md:my-0 font-bold`}
+        </div>
+      </div>
+      <div className="ml-4">
+        <li>{NoticeItems[0].content}</li>
+        <li>{NoticeItems[1].content}</li>
+        <li>{NoticeItems[2].content}</li>
+        {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
+      </div>
+
+      {isDisplay && (
+        <div className="absolute flex items-center justify-center z-10 top-0 left-0 h-full w-full">
+          <div
+            className="h-full w-full bg-black opacity-50"
+            onClick={() => setIsDisplay(false)}
+          />
+
+          <div
+            className="absolute z-40 flex flex-col top-[150px] items-center md:max-w-3xl w-[90%] p-2 pt-5
+            bg-[#B7A692] rounded-2xl shadow-lg shadow-black"
+          >
+            <div className="ml-4 text-black">
+              <div className="font-bold">お知らせ全件</div>
+              {NoticeItems.map((item) => (
+                <li key={item.id}>{item.content}</li>
+              ))}
+              {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
+            </div>
+            <div
+              className={`${ToClickTW.regular} font-normal w-13`}
+              onClick={() => {
+                setIsDisplay(false);
+              }}
             >
-              入力を維持するために <br />
-              更新しない
-            </button>
+              閉じる
+            </div>
           </div>
         </div>
       )}
+    </div>
+  );
+};
 
-      <div>〇お知らせ</div>
-      <div className="ml-4">
-        <div className="pl-6">機能追加を順次予定しております。</div>
-        {NoticeItems.map((item) => (
-          <li key={item.id}>{item.content}</li>
-        ))}
-        {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
-      </div>
-    </>
+const NoticeLink = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <Link href={href} className="font-bold hover:opacity-50 hover:underline">
+      {children}
+    </Link>
   );
 };
 
@@ -50,30 +79,35 @@ type NoticeItem = {
 
 const NoticeItems: NoticeItem[] = [
   {
-    id: "notice-2024-06-03",
-    content: (
-      <>
-        <Link href="/sings/karaoke" className="font-bold">
-          「カラオケ」
-        </Link>
-        ページの検索機能を強化(6/3)
-      </>
-    ),
+    id: "notice-2024-10-22",
+    content: "10/20～10/22におけるサイトが不安定な問題の解決 (10/23)",
   },
+
   {
     id: "notice-2024-10-18",
     content: (
       <>
-        <Link href="/user/signin" className="font-bold">
-          「ログイン」
-        </Link>
-        ページのデザインとエラー表示の改善、ログインできない不具合の修正(10/18)
+        <NoticeLink href="/user/signin">「ログイン」</NoticeLink>
+        ページのデザインとエラー表示の改善、ログインできない不具合の修正 (10/18)
       </>
     ),
   },
   {
-    id: "notice-2024-10-22",
-    content:
-      "10/20～10/22におけるサイトが不安定な問題を解決しました。引き続きご利用いただけますと幸いです。",
+    id: "notice-2024-06-03",
+    content: (
+      <>
+        <NoticeLink href="/sings/karaoke">「カラオケ」</NoticeLink>
+        ページの検索機能を強化 (6/3)
+      </>
+    ),
+  },
+  {
+    id: "notice-2024-05-30",
+    content: (
+      <>
+        <NoticeLink href="https://x.com/i_mo_5">「妹望おいも」</NoticeLink>
+        誕生日(5/30)
+      </>
+    ),
   },
 ];

--- a/t0016Next/myapp/src/features/notice/notice.tsx
+++ b/t0016Next/myapp/src/features/notice/notice.tsx
@@ -1,0 +1,79 @@
+import { ToClickTW } from "@/styles/tailwiind";
+import Link from "next/link";
+import { useState } from "react";
+
+export const TopPageNotice = () => {
+  const [isDisplay, setIsDisplay] = useState(false);
+
+  return (
+    <>
+      {isDisplay && (
+        <div
+          className="absolute z-40 top-[-150px] h-52 w-[86%] md:w-96  bg-[#B7A692]
+            p-2 pt-5 rounded-2xl shadow-lg shadow-black"
+        >
+          <div className="flex flex-col item-center md:text-2xl font-bold">
+            <span className="mx-auto">登録完了しました。</span>
+            <span className="flex mx-auto">
+              ページ内のリストを更新しますか？
+            </span>
+          </div>
+          <div className="flex flex-col md:flex-row md:text-xl mt-2 md:mt-6">
+            <button
+              type="button"
+              onClick={() => setIsDisplay(false)}
+              className={`${ToClickTW.boldChoice} p-2 mx-auto mt-4 md:my-0 font-bold`}
+            >
+              入力を維持するために <br />
+              更新しない
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div>〇お知らせ</div>
+      <div className="ml-4">
+        <div className="pl-6">機能追加を順次予定しております。</div>
+        {NoticeItems.map((item) => (
+          <li key={item.id}>{item.content}</li>
+        ))}
+        {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
+      </div>
+    </>
+  );
+};
+
+type NoticeItem = {
+  id: string;
+  content: React.ReactNode;
+};
+
+const NoticeItems: NoticeItem[] = [
+  {
+    id: "notice-2024-06-03",
+    content: (
+      <>
+        <Link href="/sings/karaoke" className="font-bold">
+          「カラオケ」
+        </Link>
+        ページの検索機能を強化(6/3)
+      </>
+    ),
+  },
+  {
+    id: "notice-2024-10-18",
+    content: (
+      <>
+        <Link href="/user/signin" className="font-bold">
+          「ログイン」
+        </Link>
+        ページのデザインとエラー表示の改善、ログインできない不具合の修正(10/18)
+      </>
+    ),
+  },
+  {
+    id: "notice-2024-10-22",
+    content:
+      "10/20～10/22におけるサイトが不安定な問題を解決しました。引き続きご利用いただけますと幸いです。",
+  },
+];

--- a/t0016Next/myapp/src/pages/index.tsx
+++ b/t0016Next/myapp/src/pages/index.tsx
@@ -62,7 +62,8 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
   return (
     <Layout pageName={pageName} isSignin={isSignin}>
       <div className="pt-1">
-        <TitleMessage />
+        <TitleGroup />
+        <TopPageNotice />
 
         <div className="flex flex-col justify-center">
           <div
@@ -178,7 +179,7 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
 };
 export default TopPage;
 
-const TitleMessage = () => {
+const TitleGroup = () => {
   return (
     <div className="flex flex-col items-center">
       <hgroup className="pb-1 md:pb-3 ">
@@ -191,9 +192,6 @@ const TitleMessage = () => {
         <h2 className="flex justify-center text-xs ms:text-sm md:text-base ">
           「ささっと把握」、「さくっと再生」、「ばばっと布教」
         </h2>
-        <h3 className="flex flex-col max-w-[1000px] mt-2">
-          <TopPageNotice />
-        </h3>
       </hgroup>
     </div>
   );

--- a/t0016Next/myapp/src/pages/index.tsx
+++ b/t0016Next/myapp/src/pages/index.tsx
@@ -21,6 +21,7 @@ import {
 import { ToClickTW } from "@/styles/tailwiind";
 import { ContextType } from "@/types/server";
 import Image from "next/image";
+import { TopPageNotice } from "@/features/notice/notice";
 
 const pageName = "Top";
 
@@ -61,41 +62,7 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
   return (
     <Layout pageName={pageName} isSignin={isSignin}>
       <div className="pt-1">
-        <div className="flex flex-col items-center">
-          <hgroup className="pb-1 md:pb-3 ">
-            <h1 className="flex justify-center text-xl sm:text-2xl md:text-3xl font-bold underline">
-              V-Karaoke (VTuber-Karaoke-Lists)
-            </h1>
-            <h2 className="flex justify-center text-sm  md:text-base">
-              「推し」の「歌枠」の聴きたい「歌」
-            </h2>
-            <h2 className="flex justify-center text-xs ms:text-sm md:text-base ">
-              「ささっと把握」、「さくっと再生」、「ばばっと布教」
-            </h2>
-            <h3 className="flex flex-col max-w-[1000px] mt-2">
-              <div>〇お知らせ</div>
-              <div className="ml-4">
-                <li>
-                  <Link href="/sings/karaoke" className="font-bold">
-                    「カラオケ」
-                  </Link>
-                  ページの検索機能を強化(6/3)
-                </li>
-                <li>
-                  <Link href="/user/signin" className="font-bold">
-                    「ログイン」
-                  </Link>
-                  ページのデザインとエラー表示の改善、ログインできない不具合の修正(10/18)
-                </li>
-                <li className="">
-                  10/20～10/22にかけてサイトが不安定となり申し訳ありませんでした。引き続きご利用いただけますと幸いです。
-                </li>
-                <div className="pl-6">機能追加を順次予定しております。</div>
-                {/* <li>本サイトは視聴機能付きの「ユーザー参加型データベース」です。ご登録をお願いします！</li> */}
-              </div>
-            </h3>
-          </hgroup>
-        </div>
+        <TitleMessage />
 
         <div className="flex flex-col justify-center">
           <div
@@ -107,7 +74,7 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
           >
             {/* 左側の要素 */}
             <div className="flex flex-col mr-1 ">
-              <div className="relative flex  justify-center">
+              <div className="relative flex justify-center">
                 <YouTubePlayer videoId={currentMovieId} start={start} />
               </div>
               <span className="relative flex md:top-2 justify-center md:mb-3">
@@ -151,47 +118,20 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
             </div>
           </div>
 
-          {vtubers.length == 0 && (
-            <div className="flex justify-center py-12">
-              <div className="flex justify-center bg-[#657261] font-bold text-xl p-6 max-w-[1200px]">
-                <span>
-                  データの取得に失敗したようです。
-                  <br />
-                  <br />
-                  ページを更新してもこの文章が表示される場合は
-                  <br />
-                  お手数ですが、
-                  <Link
-                    href="https://twitter.com/shari_susi"
-                    className="text-3xl text-[#b3d854] underline mx-2"
-                  >
-                    開発者のX
-                  </Link>
-                  にDMいただけますと幸いです。
-                  <br />
-                  <br />
-                  サーバーが落ちている可能性があります。
-                </span>
-              </div>
-            </div>
-          )}
+          {vtubers.length == 0 && <FailedMessge />}
 
-          {/* 表達 */}
           <div
             id="feature"
-            className={`flex-col md:flex-row justify-center
-                max-w-[1000px] w-full mx-auto inline-block
-                top-0 p-1
-                `}
+            className={`flex-col md:flex-row justify-center max-w-[1000px] w-full mx-auto inline-block top-0 p-1`}
           >
-            <div className="mt-4 max-w-[1000px] ">
-              <div className="flex ">
+            <div className="mt-4 max-w-[1000px]">
+              <div className="flex">
                 <Image
                   src="/content/human_white.svg"
                   className="h-5 mr-1"
                   width={24}
                   height={20}
-                  alt=""
+                  alt="humans icon"
                 />
                 <h2 className="h-5 flex-1 mb-1">配信者</h2>
               </div>
@@ -205,7 +145,7 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
                     className="h-5 mr-1"
                     width={24}
                     height={20}
-                    alt=""
+                    alt="movie icon"
                   />
                   歌枠(動画)
                 </h2>
@@ -220,7 +160,7 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
                     className="h-5 mr-1"
                     width={24}
                     height={20}
-                    alt=""
+                    alt="note icon"
                   />
                   歌
                 </h2>
@@ -237,6 +177,45 @@ const TopPage = ({ posts, isSignin }: TopPage) => {
   );
 };
 export default TopPage;
+
+const TitleMessage = () => {
+  return (
+    <div className="flex flex-col items-center">
+      <hgroup className="pb-1 md:pb-3 ">
+        <h1 className="flex justify-center text-xl sm:text-2xl md:text-3xl font-bold underline">
+          V-Karaoke (VTuber-Karaoke-Lists)
+        </h1>
+        <h2 className="flex justify-center text-sm  md:text-base">
+          「推し」の「歌枠」の聴きたい「歌」
+        </h2>
+        <h2 className="flex justify-center text-xs ms:text-sm md:text-base ">
+          「ささっと把握」、「さくっと再生」、「ばばっと布教」
+        </h2>
+        <h3 className="flex flex-col max-w-[1000px] mt-2">
+          <TopPageNotice />
+        </h3>
+      </hgroup>
+    </div>
+  );
+};
+
+const FailedMessge = () => {
+  return (
+    <div className="flex justify-center py-12">
+      <div className="flex flex-col  items-center bg-[#657261] font-bold text-xl p-6 max-w-[1200px]">
+        <span className="mb-3">データの取得に失敗しました。</span>
+        <span>ページ更新してもこの文章が表示された場合は</span>
+        <Link
+          href="https://twitter.com/shari_susi"
+          className="text-3xl text-[#b3d854] underline hover:opacity-70"
+        >
+          開発者のX
+        </Link>
+        <span>にDMいただけますと幸いです。</span>
+      </div>
+    </div>
+  );
+};
 
 /////////////////////////////////////////////////////////////////////////////
 export async function getServerSideProps(context: ContextType) {

--- a/t0016Next/myapp/src/pages/vtuber/[vtuber_kana].tsx
+++ b/t0016Next/myapp/src/pages/vtuber/[vtuber_kana].tsx
@@ -1,184 +1,223 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import https from 'https';
-import axios, { AxiosRequestConfig } from 'axios';
-import Link from 'next/link';
+import React, { useState, useEffect, useMemo } from "react";
+import https from "https";
+import axios, { AxiosRequestConfig } from "axios";
+import Link from "next/link";
 
-import { domain } from '@/../env'
-import { Layout } from '@/components/layout/Layout'
-import { ToClickTW } from '@/styles/tailwiind';
-import type { ReceivedKaraoke, ReceivedMovie } from '@/types/vtuber_content';
-import { YouTubePlayer } from '@/components/moviePlayer/YoutubePlayer'
-import { ConvertStringToTime, ExtractVideoId } from '@/components/Conversion'
-import { DropDownAllMovie } from '@/components/dropDown/Movie';
-import { NotFoundVtuber } from '@/components/layout/Main';
-import { GetServerSidePropsContext } from 'next';
-import { generateRandomNumber } from '@/components/SomeFunction';
-import KaraokeFilterTableWithoutVTuberName from '@/components/table-tanstack/Karaoke/KaraokeFilterTableWithoutVTuberName';
+import { domain } from "@/../env";
+import { Layout } from "@/components/layout/Layout";
+import { ToClickTW } from "@/styles/tailwiind";
+import type { ReceivedKaraoke, ReceivedMovie } from "@/types/vtuber_content";
+import { YouTubePlayer } from "@/components/moviePlayer/YoutubePlayer";
+import { ConvertStringToTime, ExtractVideoId } from "@/components/Conversion";
+import { DropDownAllMovie } from "@/components/dropDown/Movie";
+import { NotFoundVtuber } from "@/components/layout/Main";
+import { GetServerSidePropsContext } from "next";
+import { generateRandomNumber } from "@/components/SomeFunction";
+import KaraokeFilterTableWithoutVTuberName from "@/components/table-tanstack/Karaoke/KaraokeFilterTableWithoutVTuberName";
 
-const pageName = "Vtuber特設ページ" // VTuberの名前になるようにレンダリングフェーズで変更している
+const pageName = "Vtuber特設ページ"; // VTuberの名前になるようにレンダリングフェーズで変更している
 
 type VtuberPage = {
-    posts: {
-        vtubers_movies: ReceivedMovie[];
-        vtubers_movies_karaokes: ReceivedKaraoke[];
-    };
-    isSignin: boolean;
-}
+  posts: {
+    vtubers_movies: ReceivedMovie[];
+    vtubers_movies_karaokes: ReceivedKaraoke[];
+  };
+  isSignin: boolean;
+};
 
 export default function VtuberOriginalPage({ posts, isSignin }: VtuberPage) {
-    const karaokes = useMemo(() => posts?.vtubers_movies_karaokes || [{} as ReceivedKaraoke], [posts]);
+  const karaokes = useMemo(
+    () => posts?.vtubers_movies_karaokes || [{} as ReceivedKaraoke],
+    [posts]
+  );
 
-    const playKaraokeNumber = generateRandomNumber(karaokes.length)
+  const playKaraokeNumber = generateRandomNumber(karaokes.length);
 
-    const url = "www.youtube.com/watch?v=kORHSmXcYNc"
-    const stringTime = "00:08:29"
-    const primaryYoutubeUrl = ExtractVideoId(karaokes[playKaraokeNumber]?.MovieUrl || url)
-    const primaryYoutubeStartTime = ConvertStringToTime(karaokes[playKaraokeNumber]?.SingStart || stringTime)
+  // TODO: ロジック正しいか確認。動画がkaraokesから選ばれてtimeが初期値になることはないか。動画は0番目や最終番目も選ばれるか。
+  const url = "www.youtube.com/watch?v=kORHSmXcYNc"; // 船長
+  const stringTime = "00:08:29"; // ピンクレディー メドレー
+  const primaryYoutubeUrl = ExtractVideoId(
+    karaokes[playKaraokeNumber]?.MovieUrl || url
+  );
+  const primaryYoutubeStartTime = ConvertStringToTime(
+    karaokes[playKaraokeNumber]?.SingStart || stringTime
+  );
 
-    const [currentMovieId, setCurrentMovieId] = useState<string>(primaryYoutubeUrl);
-    const [start, setStart] = useState<number>(primaryYoutubeStartTime)
+  const [currentMovieId, setCurrentMovieId] =
+    useState<string>(primaryYoutubeUrl);
+  const [start, setStart] = useState<number>(primaryYoutubeStartTime);
 
-    const handleMovieClickYouTube = (url: string, start: number) => {
-        setCurrentMovieId(ExtractVideoId(url));
-        setStart(start);
-    }
+  const handleMovieClickYouTube = (url: string, start: number) => {
+    setCurrentMovieId(ExtractVideoId(url));
+    setStart(start);
+  };
 
-    const [selectedMovie, setSelectedMovie] = useState<string>("");
-    const [filteredKaraokes, setFilteredKarakes] = useState<ReceivedKaraoke[]>([]);
+  const [selectedMovie, setSelectedMovie] = useState<string>("");
+  const [filteredKaraokes, setFilteredKarakes] = useState<ReceivedKaraoke[]>(
+    []
+  );
 
-    useEffect(() => {
-        const filterdkaraokes = FilterKaraokesByUrl(karaokes, selectedMovie)
-        setFilteredKarakes(filterdkaraokes)
-    }, [karaokes, selectedMovie]);
+  useEffect(() => {
+    const filterdkaraokes = FilterKaraokesByUrl(karaokes, selectedMovie);
+    setFilteredKarakes(filterdkaraokes);
+  }, [karaokes, selectedMovie]);
 
-    // propsとして必要
-    const [selectedPost, setSelectedPost] = useState<ReceivedKaraoke>({} as ReceivedKaraoke)
+  // propsとして必要
+  const [selectedPost, setSelectedPost] = useState<ReceivedKaraoke>(
+    {} as ReceivedKaraoke
+  );
 
-    if (karaokes.length == 0) {
-        return (
-            <Layout pageName={pageName} isSignin={isSignin}>
-                <div className='flex flex-col w-full max-w-[1000px] mx-auto'>
-                    <div className={`pt-6 flex flex-col items-center`}>
-                        <div className={`flex`}>
-                            <div id="feature"
-                                className={`flex flex-col md:flex-row bg-[#657261] rounded
-                                max-w-[1000px]  md:h-[265px] h-full w-full mx-auto
-                                top-0 p-1 `
-                                }
-                            >
-                                {/* 左側の要素 */}
-                                <div className='flex flex-col mr-1 '>
-                                    <div className='relative flex  justify-center'>
-                                        <YouTubePlayer videoId={currentMovieId} start={start} />
-                                    </div>
-                                </div>
-
-                                {/* 右側の要素 */}
-                                <div id="right" className={`relative  px-1 rounded border`}>
-                                    <NotFoundVtuber />
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </Layout>
-        )
-    }
-
+  if (karaokes.length == 0) {
     return (
-        <Layout pageName={`${karaokes[0].VtuberName}`} isSignin={isSignin}>
-            <div className='flex flex-col w-full max-w-[1000px] mx-auto'>
-                <div className={`pt-6 flex flex-col items-center`}>
-                    <div className={`flex`}>
-                        <div id="feature"
-                            className={`flex flex-col md:flex-row bg-[#657261] rounded
+      <Layout pageName={pageName} isSignin={isSignin}>
+        <div className="flex flex-col w-full max-w-[1000px] mx-auto">
+          <div className={`pt-6 flex flex-col items-center`}>
+            <div className={`flex`}>
+              <div
+                id="feature"
+                className={`flex flex-col md:flex-row bg-[#657261] rounded
+                                max-w-[1000px]  md:h-[265px] h-full w-full mx-auto
+                                top-0 p-1 `}
+              >
+                {/* 左側の要素 */}
+                <div className="flex flex-col mr-1 ">
+                  <div className="relative flex  justify-center">
+                    <YouTubePlayer videoId={currentMovieId} start={start} />
+                  </div>
+                </div>
+
+                {/* 右側の要素 */}
+                <div id="right" className={`relative  px-1 rounded border`}>
+                  <NotFoundVtuber />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout pageName={`${karaokes[0].VtuberName}`} isSignin={isSignin}>
+      <div className="flex flex-col w-full max-w-[1000px] mx-auto">
+        <div className={`pt-6 flex flex-col items-center`}>
+          <div className={`flex`}>
+            <div
+              id="feature"
+              className={`flex flex-col md:flex-row bg-[#657261] rounded
                                 max-w-[1000px]  md:h-[265px] h-full w-full mx-auto
                                 top-0 p-1
                             `}
-                        >
-                            {/* 左側の要素 */}
-                            <div className='flex flex-col mr-1 '>
-                                <div className='relative flex  justify-center'>
-                                    <YouTubePlayer videoId={currentMovieId} start={start} />
-                                </div>
-                            </div>
+            >
+              {/* 左側の要素 */}
+              <div className="flex flex-col mr-1 ">
+                <div className="relative flex  justify-center">
+                  <YouTubePlayer videoId={currentMovieId} start={start} />
+                </div>
+              </div>
 
-                            {/* 右側の要素 */}
-                            <div id="right" className={`relative  px-1 rounded border`}>
-                                <div className='flex py-3 text-black bg-[#FFF6E4] justify-center rounded-xl'>
-                                    <span className='text-xl font-bold mr-2'> {karaokes?.[0].VtuberName}</span>
-                                    <span className='mt-1'>の歌枠</span>
-                                </div>
-                                <span >動画絞込み（入力できます）</span>
-                                <DropDownAllMovie
-                                    preMovies={posts.vtubers_movies}
-                                    setSelectedMovie={setSelectedMovie}
-                                // clearMovieHandler={clearMovieHandler}
-                                />
-                                <div className='pt-5'>
-                                    <span>お探しの歌枠や歌がありませんか？</span> <br />
-                                    <Link className={`${ToClickTW.regular} justify-center float-right px-3 mr-2`}
-                                        href="/crud/create" >データを登録する</Link>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+              {/* 右側の要素 */}
+              <div id="right" className={`relative  px-1 rounded border`}>
+                <div className="flex py-3 text-black bg-[#FFF6E4] justify-center rounded-xl">
+                  <span className="text-xl font-bold mr-2">
+                    {" "}
+                    {karaokes?.[0].VtuberName}
+                  </span>
+                  <span className="mt-1">の歌枠</span>
                 </div>
-                <div className="flex flex-col w-full">
-                    <KaraokeFilterTableWithoutVTuberName
-                        posts={filteredKaraokes}
-                        handleMovieClickYouTube={handleMovieClickYouTube}
-                        setSelectedPost={setSelectedPost}
-                    />
+                <span>動画絞込み（入力できます）</span>
+                <DropDownAllMovie
+                  preMovies={posts.vtubers_movies}
+                  setSelectedMovie={setSelectedMovie}
+                  // clearMovieHandler={clearMovieHandler}
+                />
+                <div className="pt-5">
+                  <span>お探しの歌枠や歌がありませんか？</span> <br />
+                  <Link
+                    className={`${ToClickTW.regular} justify-center float-right px-3 mr-2`}
+                    href="/crud/create"
+                  >
+                    データを登録する
+                  </Link>
                 </div>
+              </div>
             </div>
-        </Layout>
-    )
+          </div>
+        </div>
+        <div className="flex flex-col w-full">
+          <KaraokeFilterTableWithoutVTuberName
+            posts={filteredKaraokes}
+            handleMovieClickYouTube={handleMovieClickYouTube}
+            setSelectedPost={setSelectedPost}
+          />
+        </div>
+      </div>
+    </Layout>
+  );
 }
 
-const FilterKaraokesByUrl = (karaokes: ReceivedKaraoke[], selectedMovie: string) => {
-    if (selectedMovie == "") {
-        return karaokes
-    } else {
-        const choiceKaraoke = karaokes.filter((karaokes: ReceivedKaraoke) => karaokes.MovieUrl === selectedMovie);
-        return choiceKaraoke
-    }
-}
+const FilterKaraokesByUrl = (
+  karaokes: ReceivedKaraoke[],
+  selectedMovie: string
+) => {
+  if (selectedMovie == "") {
+    return karaokes;
+  } else {
+    const choiceKaraoke = karaokes.filter(
+      (karaokes: ReceivedKaraoke) => karaokes.MovieUrl === selectedMovie
+    );
+    return choiceKaraoke;
+  }
+};
 
 /////////////////////////////////////////////////////////////////////////////
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-    const kana = context.query.vtuber_kana;
+  const kana = context.query.vtuber_kana;
 
-    const rawCookie = context.req.headers.cookie;
-    const sessionToken = rawCookie?.split(';').find((cookie: string) => cookie.trim().startsWith('auth-token='))?.split('=')[1];
-    let isSignin = false
-    if (sessionToken) {
-        isSignin = true
-    }
+  const rawCookie = context.req.headers.cookie;
+  const sessionToken = rawCookie
+    ?.split(";")
+    .find((cookie: string) => cookie.trim().startsWith("auth-token="))
+    ?.split("=")[1];
+  let isSignin = false;
+  if (sessionToken) {
+    isSignin = true;
+  }
 
-    console.log("pageName, kana, sessionToken, isSigni =", pageName, kana, sessionToken, isSignin) //アクセス数記録のため
+  // アクセス数確認用
+  console.log(
+    `pageName: ${pageName}, "vtuber:${kana}, ログイン: ${
+      isSignin ? sessionToken : "false"
+    }`
+  );
 
-    const httpsAgent = new https.Agent({ rejectUnauthorized: false });
-    const options: AxiosRequestConfig = {
-        headers: {
-            cookie: `auth-token=${sessionToken}`,
-        },
-        withCredentials: true,
-        httpsAgent: process.env.NODE_ENV === "production" ? undefined : httpsAgent
-    };
+  const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+  const options: AxiosRequestConfig = {
+    headers: {
+      cookie: `auth-token=${sessionToken}`,
+    },
+    withCredentials: true,
+    httpsAgent: process.env.NODE_ENV === "production" ? undefined : httpsAgent,
+  };
 
-    let resData = null;
-    try {
-        const res = await axios.get(`${domain.backendHost}/vcontents/vtuber/${kana}`, options);
-        resData = res.data;
-    } catch (error) {
-        console.log("erroe in axios.get:", error);
-    }
-    return {
-        props: {
-            posts: resData,
-            isSignin: isSignin,
-        }
-    }
+  let resData = null;
+  try {
+    const res = await axios.get(
+      `${domain.backendHost}/vcontents/vtuber/${kana}`,
+      options
+    );
+    resData = res.data;
+  } catch (error) {
+    console.log(
+      `error in axios.get with \`/vcontents/vtuber/${kana}\`: `,
+      error
+    );
+  }
+  return {
+    props: {
+      posts: resData,
+      isSignin: isSignin,
+    },
+  };
 }
-

--- a/t0016Next/myapp/src/styles/tailwiind.js
+++ b/t0016Next/myapp/src/styles/tailwiind.js
@@ -1,60 +1,65 @@
 export const HeaderCss = {
-	regular: "fixed w-full bg-[#252525]  md:w-full z-20"
-}
+  regular: "fixed w-full bg-[#252525]  md:w-full z-20",
+};
 
 export const FooterTW = {
-	regular: "bottom-5 "
-}
+  regular: "bottom-5 ",
+};
 
 export const MainTW = {
-	regular: "fixed w-full bg-[#252525] "
-}
+  regular: "fixed w-full bg-[#252525] ",
+};
 
 export const TableCss = {
-	// whole
-	regular: "bg-[#FFF6E4] text-black w-full md:max-w-[1000px] text-left whitespace-nowrap ",
-	minRandom: "bg-[#FFF6E4] text-black w-full text-left whitespace-nowrap",
+  // whole
+  regular:
+    "bg-[#FFF6E4] text-black w-full md:max-w-[1000px] text-left whitespace-nowrap ",
+  minRandom: "bg-[#FFF6E4] text-black w-full text-left whitespace-nowrap",
 
-	// tr, td
-	regularTd: "",
-	regularThead: "border-b border-[#776D5C] ",
-	regularTr: "border-b border-[#B7A692]  odd:bg-[#f9f3e9] md:odd:bg-[#FFF6E4]",
+  // tr, td
+  regularTd: "",
+  regularThead: "border-b border-[#776D5C] ",
+  regularTr: "border-b border-[#B7A692]  odd:bg-[#f9f3e9] md:odd:bg-[#FFF6E4]",
 
-	// data in column
-	favoriteColumn: "rounded-full w-10 bg-[#fbd5d2] text-black ",
-	deleteColumn: "",
-	pageNationSingle: "px-1 md:px-2 bg-[#657261] rounded-2xl hover:bg-[#B7A692]",
-	pageNationDouble: "px-1 md:px-2 bg-[#657261] rounded-2xl hover:bg-[#B7A692]"
-}
+  // data in column
+  favoriteColumn: "rounded-full w-10 bg-[#fbd5d2] text-black ",
+  deleteColumn: "",
+  pageNationSingle: "px-1 md:px-2 bg-[#657261] rounded-2xl hover:bg-[#B7A692]",
+  pageNationDouble: "px-1 md:px-2 bg-[#657261] rounded-2xl hover:bg-[#B7A692]",
+};
 
 export const ToClickTW = {
-	regular: "bg-[#776D5C] hover:bg-[#575044] text-white font-semibold rounded-md p-1",
-	formButton:
-		"bg-[#B7A692] text-white font-semibold rounded-md p-1 text-center shadow-sm shadow-black shadow-black hover:shadow-inner hover:shadow-lg hover:shadow-[#FFF6E4]",
-	textSize: "bg-[#776D5C] text-white font-semibold rounded-md",
-	choice: "md:hover:bg-[#657261] border border-[#575044] text-white font-semibold " + " w-[100px] md:[120px] h-[40px] md:h-[40px] rounded-md",
-	decide:
-		"bg-[#657261] shadow-lg hover:bg-[#1F2724] shadow-black hover:shadow-inner hover:shadow-[#FFF6E4] text-white font-semibold rounded-md" +
-		" py-1 px-3 text-center ",
-	link: "",
-	input:
-		"hover:drop-shadow-md shadow appearance-none border" +
-		" rounded w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline bg-gray-300 ",
-	hamburger: "bg-[#776D5C] hover:bg-[#575044] text-white font-semibold px-auto rounded-l-full  ",
-	boldChoice: "bg-[#776D5C] hover:bg-[#657261] text-white font-bold rounded-md"
-}
+  regular:
+    "bg-[#776D5C] hover:bg-[#575044] hover:cursor-pointer text-white font-semibold rounded-md p-1",
+  formButton:
+    "bg-[#B7A692] text-white font-semibold rounded-md p-1 text-center shadow-sm shadow-black shadow-black hover:shadow-inner hover:shadow-lg hover:shadow-[#FFF6E4]",
+  textSize: "bg-[#776D5C] text-white font-semibold rounded-md",
+  choice:
+    "md:hover:bg-[#657261] border border-[#575044] text-white font-semibold " +
+    " w-[100px] md:[120px] h-[40px] md:h-[40px] rounded-md",
+  decide:
+    "bg-[#657261] shadow-lg hover:bg-[#1F2724] shadow-black hover:shadow-inner hover:shadow-[#FFF6E4] text-white font-semibold rounded-md" +
+    " py-1 px-3 text-center ",
+  link: "",
+  input:
+    "hover:drop-shadow-md shadow appearance-none border" +
+    " rounded w-full py-2 px-3 text-black leading-tight focus:outline-none focus:shadow-outline bg-gray-300 ",
+  hamburger:
+    "bg-[#776D5C] hover:bg-[#575044] text-white font-semibold px-auto rounded-l-full  ",
+  boldChoice: "bg-[#776D5C] hover:bg-[#657261] text-white font-bold rounded-md",
+};
 
 export const YouTubeTW = {
-	// regular: "top-0 p-2 bg-[#657261] max-w-md mx-auto z-40"
-	regular: ""
-}
+  // regular: "top-0 p-2 bg-[#657261] max-w-md mx-auto z-40"
+  regular: "",
+};
 
 export const FormTW = {
-	need: "bg-[#ff0000] text-white text-[10px] font-bold px-0.5 py-0 rounded-md h-4",
-	label: "block text-gray-700 text-sm font-bold ",
-	// horizon: "border-[#2e9836] border-2 mx-10 my-2",
-	horizon: "border-[#66a962] border-2 mx-10 my-2"
-}
+  need: "bg-[#ff0000] text-white text-[10px] font-bold px-0.5 py-0 rounded-md h-4",
+  label: "block text-gray-700 text-sm font-bold ",
+  // horizon: "border-[#2e9836] border-2 mx-10 my-2",
+  horizon: "border-[#66a962] border-2 mx-10 my-2",
+};
 
 // #b3d854 葉脈の本筋の明るいところ (蛍光黄色みたいな緑)
 // #88ba54 葉っぱの濃いところ (↓より明るい)


### PR DESCRIPTION
- close #268

### 概要
- お知らせでtopページを圧迫し始めたので表示数を減らした
- modalで全お知らせを閲覧できるようにした
- ついでに、top pageのコメント部分をコンポーネント分けした
 
- ?ボタン設置、topページそのものには3件まで
  <image src="https://github.com/user-attachments/assets/e822c17a-0d2d-4302-9574-182cea5cb1ff" width="500px"/>
- ？ボタンでmodal開く
  <image src="https://github.com/user-attachments/assets/3c83d023-7bd1-4e96-9629-0459be9f889f" width="500px"/>
- お知らせが増えたらスクロールバー対応
  <image src="https://github.com/user-attachments/assets/d5d55bb8-c439-4777-93f5-4ca4bb85647a" width="500px"/>
- スマホ
  <image src="https://github.com/user-attachments/assets/87c7f0e6-2736-441b-8ffe-b61bae9bf056"  width="300px"/>

