### PR TITLE
feat: DBバックアップ用S3バケットをTerraform管理下に追加

### DIFF
--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -14,6 +14,11 @@ resource "aws_iam_policy" "policy_get_s3" {
           "${aws_s3_bucket.api_env.arn}/.env",
           "${aws_s3_bucket.app_env.arn}/.env",
         ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "${aws_s3_bucket.db_backup.arn}/*"
       }
     ]
   })

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -29,3 +29,19 @@ resource "aws_s3_bucket_public_access_block" "app_env" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# -------------------------------------------------------------------
+# S3: DB バックアップ
+# -------------------------------------------------------------------
+resource "aws_s3_bucket" "db_backup" {
+  bucket = "v-kara-db-backup"
+}
+
+resource "aws_s3_bucket_public_access_block" "db_backup" {
+  bucket = aws_s3_bucket.db_backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
## 変更内容

- `infra/terraform/s3.tf` — `v-kara-db-backup` バケット追加（public access block 付き）
- `infra/terraform/ec2.tf` — EC2 の IAM ポリシーに `s3:PutObject` 権限を追加（Makefile のバックアップコマンドが S3 に書き込むため）

## 確認事項

- [ ] バケットが既に存在する場合は `terraform import aws_s3_bucket.db_backup v-kara-db-backup` を実行済みであること
- [ ] `terraform plan` でリソースの追加・変更内容を確認済みであること