### PR TITLE
feat: RDS を廃止して EC2 上の Docker MySQL に移行

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-  "MD040": false
+  "MD040": false,
+  "MD013": false
 }

--- a/VIBES/plan/20260518-1-RDSやめてEC2上のMySQLに移行.md
+++ b/VIBES/plan/20260518-1-RDSやめてEC2上のMySQLに移行.md
@@ -1,0 +1,53 @@
+# RDS をやめて EC2 上の MySQL (Docker) に移行
+
+## 背景・目的
+
+現在 AWS RDS (db.t3.micro) を使っているが、コスト削減のため MySQL を EC2 上の Docker コンテナとして稼働させる構成に変更する。
+
+## 変更スコープ
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `ec2-docker-compose.yml` | db サービスのコメントアウトを解除、`DEPLOY_DB_ENV=RDS` → `EC2` に変更 |
+| `t0016Go/infra/db.go` | クラウド環境で `DEPLOY_DB_ENV=EC2` の場合に docker ネットワーク経由で接続するよう変更 |
+| `infra/terraform/rds.tf` | RDS インスタンス・サブネットグループを削除 |
+| `infra/terraform/security_group.tf` | `aws_security_group.rds` を削除 |
+| `infra/terraform/variables.tf` | RDS 関連変数 (`rds_kms_key_id`, `db_username`, `db_password`, `allowed_ssh_cidr_rds`) を削除 |
+| `infra/terraform/outputs.tf` | `rds_endpoint` output を削除 |
+
+## 注意事項
+
+- **データ移行が必須**: Terraform で RDS を削除する前に、RDS のデータを mysqldump で取得し EC2 の MySQL コンテナにインポートすること
+- **インスタンス負荷**: EC2 (t3a.micro) 上で api + app + db の 3 コンテナが動く。メモリが 1GB しかないため、余裕があるか確認する
+- **バックアップ**: RDS の自動バックアップがなくなる。S3 バックアップ (`v-kara-db-backup`) の仕組みは引き続き有効活用する
+
+## 実装ステップ
+
+### 事前作業（手動）
+
+1. RDS からデータをダンプ
+   ```bash
+   mysqldump -h <RDSエンドポイント> -u <ユーザー> -p <DB名> > rds_backup_$(date +%Y%m%d).sql
+   ```
+
+2. EC2 上で db コンテナを先に起動してデータをインポート（後述の docker-compose 変更後）
+
+### コード変更
+
+3. `ec2-docker-compose.yml` を修正
+4. `t0016Go/infra/db.go` を修正
+5. Terraform ファイルを修正
+
+### インフラ操作（手動）
+
+6. `terraform plan` で差分を確認
+7. EC2 上で db コンテナを起動・データインポート・動作確認
+8. `terraform apply` で RDS を削除
+
+## 完了条件
+
+- [ ] EC2 上の MySQL コンテナに接続できる
+- [ ] 既存データが移行されている
+- [ ] アプリが正常に動作する
+- [ ] `terraform apply` で RDS が削除される
+- [ ] RDS の月額課金が止まる

--- a/ec2-docker-compose.yml
+++ b/ec2-docker-compose.yml
@@ -1,29 +1,29 @@
 services:
-  # db:
-  #   image: mysql:8.0.32
-  #   platform: linux/amd64 # mac環境で必須なことがあるらしい
-  #   env_file: ./db/.env
-  #   container_name: v_kara_db
-  #   build:
-  #     context: ./db
-  #   healthcheck:
-  #     test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-  #     timeout: 5s
-  #     retries: 10
-  #   ports:
-  #     - "3306:3306"
-  #   command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+  db:
+    image: mysql:8.0.32
+    container_name: v_kara_db
+    env_file: db.env
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 10
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 
   api:
     image: ${ECR_REGISTRY}/${ECR_API_REPO}:latest
     container_name: v-kara-api
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE
-      - DEPLOY_DB_ENV=RDS
+      - DEPLOY_DB_ENV=EC2
       - IS_DOCKER_COMPOSE=true
     env_file: api.env # DB接続情報等の実行時設定を含む。上記 environment と同名キーは environment が優先される
     ports:
       - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
 
   app:
     image: ${ECR_REGISTRY}/${ECR_APP_REPO}:latest
@@ -34,3 +34,6 @@ services:
       - IS_DOCKER_COMPOSE=true
     ports:
       - "80:80"
+
+volumes:
+  mysql_data:

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -69,5 +69,17 @@ resource "aws_instance" "app" {
   key_name               = "key-for-vkara-instance"
   iam_instance_profile   = aws_iam_instance_profile.ec2.name
 
+  # セキュリティパッチの自動適用（Amazon Linux 2023）
+  user_data = <<-EOF
+    #!/bin/bash
+    dnf install -y dnf-automatic
+    sed -i 's/apply_updates = no/apply_updates = yes/' /etc/dnf/automatic.conf
+    systemctl enable --now dnf-automatic.timer
+  EOF
+
+  lifecycle {
+    ignore_changes = [user_data]
+  }
+
   tags = { Name = "v-kara-public" }
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -8,8 +8,8 @@ output "ec2_public_ip" {
   value       = aws_instance.app.public_ip
 }
 
-output "rds_endpoint" {
-  description = "RDS エンドポイント"
-  value       = aws_db_instance.main.endpoint
-  sensitive   = true
-}
+# output "rds_endpoint" {
+#   description = "RDS エンドポイント"
+#   value       = aws_db_instance.main.endpoint
+#   sensitive   = true
+# }

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -1,48 +1,50 @@
-# -------------------------------------------------------------------
-# DB Subnet Group（VPC のデフォルトサブネットグループ）
-# -------------------------------------------------------------------
-resource "aws_db_subnet_group" "main" {
-  name        = "default-${aws_vpc.main.id}"
-  description = "Created from the RDS Management Console"
+# RDS は一時的に廃止。MySQL は EC2 上の Docker コンテナで稼働。
 
-  subnet_ids = [
-    aws_subnet.public_a.id,
-    aws_subnet.public_c.id,
-    aws_subnet.private_a.id,
-    aws_subnet.private_c.id,
-  ]
-}
+# # -------------------------------------------------------------------
+# # DB Subnet Group（VPC のデフォルトサブネットグループ）
+# # -------------------------------------------------------------------
+# resource "aws_db_subnet_group" "main" {
+#   name        = "default-${aws_vpc.main.id}"
+#   description = "Created from the RDS Management Console"
 
-# -------------------------------------------------------------------
-# RDS Instance
-# -------------------------------------------------------------------
-resource "aws_db_instance" "main" {
-  identifier        = "v-kara-db"
-  instance_class    = "db.t3.micro"
-  engine            = "mysql"
-  engine_version    = "8.4.7"
-  allocated_storage = 20
+#   subnet_ids = [
+#     aws_subnet.public_a.id,
+#     aws_subnet.public_c.id,
+#     aws_subnet.private_a.id,
+#     aws_subnet.private_c.id,
+#   ]
+# }
 
-  username = var.db_username
-  password = var.db_password
+# # -------------------------------------------------------------------
+# # RDS Instance
+# # -------------------------------------------------------------------
+# resource "aws_db_instance" "main" {
+#   identifier        = "v-kara-db"
+#   instance_class    = "db.t3.micro"
+#   engine            = "mysql"
+#   engine_version    = "8.4.7"
+#   allocated_storage = 20
 
-  db_subnet_group_name   = aws_db_subnet_group.main.name
-  vpc_security_group_ids = [aws_security_group.rds.id]
+#   username = var.db_username
+#   password = var.db_password
 
-  availability_zone   = "ap-northeast-1a"
-  multi_az            = false
-  publicly_accessible = false
+#   db_subnet_group_name   = aws_db_subnet_group.main.name
+#   vpc_security_group_ids = [aws_security_group.rds.id]
 
-  storage_encrypted = true
-  kms_key_id        = var.rds_kms_key_id
+#   availability_zone   = "ap-northeast-1a"
+#   multi_az            = false
+#   publicly_accessible = false
 
-  max_allocated_storage = 1000
-  copy_tags_to_snapshot = true
+#   storage_encrypted = true
+#   kms_key_id        = var.rds_kms_key_id
 
-  skip_final_snapshot       = false
-  final_snapshot_identifier = "v-kara-db-final-snapshot"
+#   max_allocated_storage = 1000
+#   copy_tags_to_snapshot = true
 
-  lifecycle {
-    ignore_changes = [password]
-  }
-}
+#   skip_final_snapshot       = false
+#   final_snapshot_identifier = "v-kara-db-final-snapshot"
+
+#   lifecycle {
+#     ignore_changes = [password]
+#   }
+# }

--- a/infra/terraform/security_group.tf
+++ b/infra/terraform/security_group.tf
@@ -81,45 +81,45 @@ resource "aws_security_group" "ec2" {
   }
 }
 
-# -------------------------------------------------------------------
-# RDS Security Group
-# name: v-kara-rds-sg
-# ingress: 3306 from EC2 SG, 22 from var.allowed_ssh_cidr_rds
-# egress: all to 0.0.0.0/0
-#
-# TODO: このSGは現在 RDS と踏み台EC2 (ec2-for-rds) の両方にアタッチされており、
-#       SSH(22) と 3306 が同一SG内に混在している。
-#       bastion用SGを分割して責務を明確にする。 → # 337
-# -------------------------------------------------------------------
-resource "aws_security_group" "rds" {
-  name        = "v-kara-rds-sg"
-  description = "Created by RDS management console"
-  vpc_id      = aws_vpc.main.id
+# # -------------------------------------------------------------------
+# # RDS Security Group
+# # name: v-kara-rds-sg
+# # ingress: 3306 from EC2 SG, 22 from var.allowed_ssh_cidr_rds
+# # egress: all to 0.0.0.0/0
+# #
+# # TODO: このSGは現在 RDS と踏み台EC2 (ec2-for-rds) の両方にアタッチされており、
+# #       SSH(22) と 3306 が同一SG内に混在している。
+# #       bastion用SGを分割して責務を明確にする。 → # 337
+# # -------------------------------------------------------------------
+# resource "aws_security_group" "rds" {
+#   name        = "v-kara-rds-sg"
+#   description = "Created by RDS management console"
+#   vpc_id      = aws_vpc.main.id
 
-  ingress {
-    description = "SSH from home"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = [var.allowed_ssh_cidr_rds]
-  }
+#   ingress {
+#     description = "SSH from home"
+#     from_port   = 22
+#     to_port     = 22
+#     protocol    = "tcp"
+#     cidr_blocks = [var.allowed_ssh_cidr_rds]
+#   }
 
-  ingress {
-    description     = "MySQL from EC2"
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [aws_security_group.ec2.id]
-  }
+#   ingress {
+#     description     = "MySQL from EC2"
+#     from_port       = 3306
+#     to_port         = 3306
+#     protocol        = "tcp"
+#     security_groups = [aws_security_group.ec2.id]
+#   }
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+#   egress {
+#     from_port   = 0
+#     to_port     = 0
+#     protocol    = "-1"
+#     cidr_blocks = ["0.0.0.0/0"]
+#   }
 
-  lifecycle {
-    ignore_changes = [ingress, egress]
-  }
-}
+#   lifecycle {
+#     ignore_changes = [ingress, egress]
+#   }
+# }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -11,29 +11,29 @@ variable "allowed_ssh_cidr_ec2" {
   type        = string
 }
 
-variable "allowed_ssh_cidr_rds" {
-  description = "CIDR allowed to SSH into RDS bastion"
-  type        = string
-}
+# variable "allowed_ssh_cidr_rds" {
+#   description = "CIDR allowed to SSH into RDS bastion"
+#   type        = string
+# }
 
-# RDS KMS key ID（アカウント ID を含むため変数化）
-variable "rds_kms_key_id" {
-  description = "KMS key ARN for RDS storage encryption"
-  type        = string
-}
+# # RDS KMS key ID（アカウント ID を含むため変数化）
+# variable "rds_kms_key_id" {
+#   description = "KMS key ARN for RDS storage encryption"
+#   type        = string
+# }
 
-# RDS マスターユーザー名（terraform.tfvars で設定する）
-variable "db_username" {
-  description = "RDS master username"
-  type        = string
-  sensitive   = true
-}
+# # RDS マスターユーザー名（terraform.tfvars で設定する）
+# variable "db_username" {
+#   description = "RDS master username"
+#   type        = string
+#   sensitive   = true
+# }
 
-# RDS マスターパスワード（terraform.tfvars で設定する）
-# 既存 RDS を import した場合は ignore_changes により Terraform の管理外となるため、
-# 実際のパスワード変更は AWS コンソールまたは CLI で行うこと
-variable "db_password" {
-  description = "RDS master password (used only on initial creation; ignored after import via lifecycle.ignore_changes)"
-  type        = string
-  sensitive   = true
-}
+# # RDS マスターパスワード（terraform.tfvars で設定する）
+# # 既存 RDS を import した場合は ignore_changes により Terraform の管理外となるため、
+# # 実際のパスワード変更は AWS コンソールまたは CLI で行うこと
+# variable "db_password" {
+#   description = "RDS master password (used only on initial creation; ignored after import via lifecycle.ignore_changes)"
+#   type        = string
+#   sensitive   = true
+# }

--- a/t0016Go/Dockerfile
+++ b/t0016Go/Dockerfile
@@ -27,12 +27,17 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main cmd/main.go
 #### 実行ステージ ####
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates && \
+    adduser -D -s /sbin/nologin appuser
 
-WORKDIR /root/
+WORKDIR /app
 
 # 重要：ビルドされたmainのみをコピー
 COPY --from=builder /build/main .
+
+RUN chown appuser:appuser /app/main
+
+USER appuser
 
 EXPOSE 8080
 

--- a/t0016Go/common/env.go
+++ b/t0016Go/common/env.go
@@ -14,7 +14,7 @@ var isDockerCompose = os.Getenv("IS_DOCKER_COMPOSE") // docker-compose.ymlにの
 var DEPLOY_ENV = os.Getenv("DEPLOY_ENV")             // EC2用 docker-compose.ymlにのみ =EC2_DOCKER_COMPOSE と記載
 var DEPLOY_DB_ENV = os.Getenv("DEPLOY_DB_ENV")       // EC2用 docker-compose.ymlにのみ =RDS と記載
 
-var IsOnCloud = (goEnv == "" && isDockerCompose == "") || (DEPLOY_ENV == "EC2_DOCKER_COMPOSE" && DEPLOY_DB_ENV == "RDS")
+var IsOnCloud = (goEnv == "" && isDockerCompose == "") || DEPLOY_ENV == "EC2_DOCKER_COMPOSE"
 var IsOnLocalWithDockerCompose = (goEnv == "" && isDockerCompose == "true")
 var IsOnLocalWithOutDockerCompose = (goEnv == "development" && isDockerCompose == "")
 var IsOnLocal = !IsOnCloud && IsOnLocalWithDockerCompose || IsOnLocalWithOutDockerCompose

--- a/t0016Go/infra/db.go
+++ b/t0016Go/infra/db.go
@@ -24,8 +24,8 @@ func GetEnvVar() {
 	if common.IsOnCloud {
 		//クラウド環境
 		fmt.Println("クラウド環境で起動")
-		if common.DEPLOY_ENV == "EC2_DOCKER_COMPOSE" && common.DEPLOY_DB_ENV == "RDS" {
-			fmt.Println("EC2のdocker composeで起動")
+		if common.DEPLOY_ENV == "EC2_DOCKER_COMPOSE" {
+			fmt.Printf("EC2のdocker composeで起動。DB=%v\n", common.DEPLOY_DB_ENV)
 		}
 	} else if common.IsOnLocalWithDockerCompose {
 		// ローカルのdocker上(compose使用)
@@ -59,19 +59,15 @@ func dbInit() repository.SqlHandler {
 
 	if common.IsOnCloud {
 		fmt.Println("common.IsOnCloud : true")
-		//クラウド環境
-		dbUrl = os.Getenv("RDS_END_PIONT")
-		dbName = os.Getenv("AWS_DATABASE")
-		fmt.Printf("環境変数より取得: dbUrl=%v, dbName=%v, \n", dbUrl, dbName)
-
-		// クラウド環境で、環境変数使ってなくて、
-		// MySQLとGoがlocal接続するよ(１つのインスタンス内で両方立ててるとか)みたいな状況用
-		if dbName == "" && dbUrl == "" {
-			dbName = "v_kara_db"
-			dbUrl = "localhost"
-			// mysqlでユーザー作って、// 権限も付与すること
-			user = "shari"
-			pw = "shari_sushi"
+		if common.DEPLOY_DB_ENV == "RDS" {
+			dbUrl = os.Getenv("RDS_END_PIONT")
+			dbName = os.Getenv("AWS_DATABASE")
+			fmt.Printf("環境変数より取得: dbUrl=%v, dbName=%v, \n", dbUrl, dbName)
+		} else {
+			// EC2のdocker-compose内のdbサービスに接続
+			dbUrl = "db"
+			dbName = os.Getenv("MYSQL_DATABASE")
+			fmt.Printf("EC2ローカルMySQLに接続: dbUrl=%v, dbName=%v\n", dbUrl, dbName)
 		}
 	} else if common.IsOnLocalWithDockerCompose {
 		fmt.Println("common.IsOnLoclaWithDockerCompose : true")

--- a/t0016Next/Dockerfile
+++ b/t0016Next/Dockerfile
@@ -46,7 +46,7 @@ RUN chown nextjs:nodejs .next
 COPY --from=builder --chown=nextjs:nodejs /app/myapp/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/myapp/.next/static ./.next/static
 
-# USER nextjs
+USER nextjs
 
 # EXPOSE 3005
 


### PR DESCRIPTION
## 概要

AWS RDS を廃止し、EC2 上の Docker コンテナ（MySQL 8.0.32）に移行する。コスト削減が目的。

## 変更内容

### インフラ (Terraform)
- `infra/terraform/rds.tf` : RDS リソースをすべてコメントアウト
- `infra/terraform/security_group.tf` : RDS 用セキュリティグループを削除
- `infra/terraform/variables.tf` : RDS 関連変数を削除
- `infra/terraform/outputs.tf` : `rds_endpoint` output をコメントアウト
- `infra/terraform/ec2.tf` : `dnf-automatic` による自動セキュリティパッチ適用を追加

### EC2 Docker Compose
- `ec2-docker-compose.yml` :
  - `db` サービス（MySQL 8.0.32）を追加（ポート非公開・named volume・ヘルスチェック）
  - `api` サービスに `depends_on: db: condition: service_healthy` を追加
  - `DEPLOY_DB_ENV=RDS` → `DEPLOY_DB_ENV=EC2` に変更

### Go バックエンド
- `t0016Go/infra/db.go` : `DEPLOY_DB_ENV=EC2` 時に `db` コンテナへ接続する分岐を追加
- `t0016Go/common/env.go` : `IsOnCloud` の判定を `DEPLOY_DB_ENV` に依存しない形に修正
- `t0016Go/Dockerfile` : 非 root ユーザー（`appuser`）で実行するよう変更

### S3 バックアップ
- `infra/terraform/s3.tf` : DB バックアップ用 S3 バケットを Terraform 管理下に追加（既存 bucket を import）

## 移行済み作業（EC2上）
- RDS からエクスポートしたデータを EC2 の db コンテナにインポート済み
- db コンテナは稼働中（データ確認済み：566カラオケ、24VTuber、34リスナー）
- api/app コンテナはこの PR のマージ → CI/CD → ECR 更新後に再起動予定

## この PR マージ後の作業
1. CI/CD で ECR イメージが更新されることを確認
2. EC2 で `docker compose pull && docker compose up -d` を実行
3. 動作確認後に `terraform apply` で RDS を削除