### PR TITLE
feat: デプロイを SSH/SCP から AWS SSM に切り替え・Port 22 廃止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,16 @@ jobs:
 
       - name: Pull and restart containers on EC2
         run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=v-kara-public" \
+                      "Name=instance-state-name,Values=running" \
+            --query "Reservations[0].Instances[0].InstanceId" \
+            --output text)
+          echo "Instance ID: $INSTANCE_ID"
+
           cat > /tmp/ssm-deploy.json << 'ENDJSON'
           {
-            "InstanceIds": ["${{ secrets.EC2_INSTANCE_ID }}"],
+            "InstanceIds": ["INSTANCE_ID_PLACEHOLDER"],
             "DocumentName": "AWS-RunShellScript",
             "TimeoutSeconds": 600,
             "Parameters": {
@@ -82,6 +89,7 @@ jobs:
             }
           }
           ENDJSON
+          sed -i "s/INSTANCE_ID_PLACEHOLDER/$INSTANCE_ID/" /tmp/ssm-deploy.json
 
           COMMAND_ID=$(aws ssm send-command \
             --cli-input-json file:///tmp/ssm-deploy.json \
@@ -92,14 +100,14 @@ jobs:
           for i in $(seq 1 60); do
             STATUS=$(aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
-              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --instance-id "$INSTANCE_ID" \
               --query "Status" --output text 2>/dev/null || echo "InProgress")
             echo "[$i/60] Status: $STATUS"
             [ "$STATUS" = "Success" ] && break
             if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ] || [ "$STATUS" = "Cancelled" ]; then
               aws ssm get-command-invocation \
                 --command-id "$COMMAND_ID" \
-                --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                --instance-id "$INSTANCE_ID" \
                 --query "StandardErrorContent" --output text
               exit 1
             fi
@@ -108,9 +116,15 @@ jobs:
 
       - name: Health check
         run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=v-kara-public" \
+                      "Name=instance-state-name,Values=running" \
+            --query "Reservations[0].Instances[0].InstanceId" \
+            --output text)
+
           cat > /tmp/ssm-healthcheck.json << 'ENDJSON'
           {
-            "InstanceIds": ["${{ secrets.EC2_INSTANCE_ID }}"],
+            "InstanceIds": ["INSTANCE_ID_PLACEHOLDER"],
             "DocumentName": "AWS-RunShellScript",
             "TimeoutSeconds": 120,
             "Parameters": {
@@ -121,6 +135,7 @@ jobs:
             }
           }
           ENDJSON
+          sed -i "s/INSTANCE_ID_PLACEHOLDER/$INSTANCE_ID/" /tmp/ssm-healthcheck.json
 
           COMMAND_ID=$(aws ssm send-command \
             --cli-input-json file:///tmp/ssm-healthcheck.json \
@@ -129,10 +144,10 @@ jobs:
 
           aws ssm wait command-executed \
             --command-id "$COMMAND_ID" \
-            --instance-id "${{ secrets.EC2_INSTANCE_ID }}"
+            --instance-id "$INSTANCE_ID"
 
           aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
-            --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+            --instance-id "$INSTANCE_ID" \
             --query "StandardOutputContent" \
             --output text

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,45 +53,86 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Copy docker-compose to EC2
-        uses: appleboy/scp-action@v0.1.7
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          source: ec2-docker-compose.yml
-          target: /home/ubuntu/v-kara/
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Pull and restart containers on EC2
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          script: |
-            cd /home/ubuntu/v-kara
-            aws s3 cp s3://${{ secrets.S3_APP_ENV_BUCKET }}/.env ./app.env
-            aws s3 cp s3://${{ secrets.S3_API_ENV_BUCKET }}/.env ./api.env
-            chmod 600 *.env
-            aws ecr get-login-password --region ap-northeast-1 \
-              | docker login --username AWS \
-                --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com
-            ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com \
-            ECR_API_REPO=${{ secrets.ECR_API_REPO }} \
-            ECR_APP_REPO=${{ secrets.ECR_APP_REPO }} \
-            docker compose -f ec2-docker-compose.yml pull
-            ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com \
-            ECR_API_REPO=${{ secrets.ECR_API_REPO }} \
-            ECR_APP_REPO=${{ secrets.ECR_APP_REPO }} \
-            docker compose -f ec2-docker-compose.yml up -d
-            rm -f api.env app.env
+        run: |
+          cat > /tmp/ssm-deploy.json << 'ENDJSON'
+          {
+            "InstanceIds": ["${{ secrets.EC2_INSTANCE_ID }}"],
+            "DocumentName": "AWS-RunShellScript",
+            "TimeoutSeconds": 600,
+            "Parameters": {
+              "commands": [
+                "mkdir -p /home/ubuntu/v-kara && cd /home/ubuntu/v-kara",
+                "curl -fsSL https://raw.githubusercontent.com/shari-sushi/V-Kara-Lists/${{ github.sha }}/ec2-docker-compose.yml -o /home/ubuntu/v-kara/ec2-docker-compose.yml",
+                "aws s3 cp s3://${{ secrets.S3_APP_ENV_BUCKET }}/.env ./app.env",
+                "aws s3 cp s3://${{ secrets.S3_API_ENV_BUCKET }}/.env ./api.env",
+                "chmod 600 *.env",
+                "aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com",
+                "ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com ECR_API_REPO=${{ secrets.ECR_API_REPO }} ECR_APP_REPO=${{ secrets.ECR_APP_REPO }} docker compose -f ec2-docker-compose.yml pull",
+                "ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com ECR_API_REPO=${{ secrets.ECR_API_REPO }} ECR_APP_REPO=${{ secrets.ECR_APP_REPO }} docker compose -f ec2-docker-compose.yml up -d",
+                "rm -f /home/ubuntu/v-kara/api.env /home/ubuntu/v-kara/app.env"
+              ]
+            }
+          }
+          ENDJSON
+
+          COMMAND_ID=$(aws ssm send-command \
+            --cli-input-json file:///tmp/ssm-deploy.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+          for i in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --query "Status" --output text 2>/dev/null || echo "InProgress")
+            echo "[$i/60] Status: $STATUS"
+            [ "$STATUS" = "Success" ] && break
+            if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ] || [ "$STATUS" = "Cancelled" ]; then
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                --query "StandardErrorContent" --output text
+              exit 1
+            fi
+            sleep 10
+          done
 
       - name: Health check
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          script: |
-            for i in $(seq 1 12); do curl -sf http://localhost:8080/health && break || { [ "$i" -eq 12 ] && exit 1 || sleep 5; }; done
-            for i in $(seq 1 12); do curl -sf http://localhost/user/signin && break || { [ "$i" -eq 12 ] && exit 1 || sleep 5; }; done
+        run: |
+          cat > /tmp/ssm-healthcheck.json << 'ENDJSON'
+          {
+            "InstanceIds": ["${{ secrets.EC2_INSTANCE_ID }}"],
+            "DocumentName": "AWS-RunShellScript",
+            "TimeoutSeconds": 120,
+            "Parameters": {
+              "commands": [
+                "for i in $(seq 1 12); do curl -sf http://localhost:8080/health && break || { [ \"$i\" -eq 12 ] && exit 1 || sleep 5; }; done",
+                "for i in $(seq 1 12); do curl -sf http://localhost/user/signin && break || { [ \"$i\" -eq 12 ] && exit 1 || sleep 5; }; done"
+              ]
+            }
+          }
+          ENDJSON
+
+          COMMAND_ID=$(aws ssm send-command \
+            --cli-input-json file:///tmp/ssm-healthcheck.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "${{ secrets.EC2_INSTANCE_ID }}"
+
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+            --query "StandardOutputContent" \
+            --output text

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Pull and restart containers on EC2
+      - name: Get EC2 Instance ID
+        id: get_instance
         run: |
           INSTANCE_ID=$(aws ec2 describe-instances \
             --filters "Name=tag:Name,Values=v-kara-public" \
@@ -68,6 +69,11 @@ jobs:
             --query "Reservations[0].Instances[0].InstanceId" \
             --output text)
           echo "Instance ID: $INSTANCE_ID"
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
+
+      - name: Pull and restart containers on EC2
+        run: |
+          INSTANCE_ID="${{ steps.get_instance.outputs.instance_id }}"
 
           cat > /tmp/ssm-deploy.json << 'ENDJSON'
           {
@@ -113,14 +119,11 @@ jobs:
             fi
             sleep 10
           done
+          [ "$STATUS" = "Success" ] || { echo "SSM command timed out after 10 minutes"; exit 1; }
 
       - name: Health check
         run: |
-          INSTANCE_ID=$(aws ec2 describe-instances \
-            --filters "Name=tag:Name,Values=v-kara-public" \
-                      "Name=instance-state-name,Values=running" \
-            --query "Reservations[0].Instances[0].InstanceId" \
-            --output text)
+          INSTANCE_ID="${{ steps.get_instance.outputs.instance_id }}"
 
           cat > /tmp/ssm-healthcheck.json << 'ENDJSON'
           {

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -80,13 +80,16 @@ resource "aws_instance" "app" {
   iam_instance_profile        = aws_iam_instance_profile.ec2.name
   associate_public_ip_address = true
 
-  # TODO: Ubuntu 24.04 向けのセキュリティパッチ自動適用に書き直す
-  # 現在の dnf コマントは Amazon Linux 用のため Ubuntu では動作しない（無視される）
   user_data = <<-EOF
     #!/bin/bash
-    dnf install -y dnf-automatic
-    sed -i 's/apply_updates = no/apply_updates = yes/' /etc/dnf/automatic.conf
-    systemctl enable --now dnf-automatic.timer
+    # SSM Agent（デプロイに SSH 不要・Port 22 を閉じるために必要）
+    snap install amazon-ssm-agent --classic
+    systemctl enable snap.amazon-ssm-agent.amazon-ssm-agent.service
+    systemctl start snap.amazon-ssm-agent.amazon-ssm-agent.service
+
+    # セキュリティパッチ自動適用（Ubuntu 向け）
+    apt-get install -y unattended-upgrades
+    dpkg-reconfigure -f noninteractive unattended-upgrades
   EOF
 
   lifecycle {

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -83,12 +83,12 @@ resource "aws_instance" "app" {
   user_data = <<-EOF
     #!/bin/bash
     # SSM Agent（デプロイに SSH 不要・Port 22 を閉じるために必要）
-    snap install amazon-ssm-agent --classic
+    snap list amazon-ssm-agent 2>/dev/null || snap install amazon-ssm-agent --classic
     systemctl enable snap.amazon-ssm-agent.amazon-ssm-agent.service
     systemctl start snap.amazon-ssm-agent.amazon-ssm-agent.service
 
     # セキュリティパッチ自動適用（Ubuntu 向け）
-    apt-get install -y unattended-upgrades
+    apt-get update -y && apt-get install -y unattended-upgrades
     dpkg-reconfigure -f noninteractive unattended-upgrades
   EOF
 


### PR DESCRIPTION
## Summary

- `appleboy/scp-action` と `appleboy/ssh-action`（SSH/SCP）を廃止し、AWS SSM Run Command 経由のデプロイに変更
- EC2 セキュリティグループの Port 22 を閉じたまま CI/CD が動くようになる
- `ec2-docker-compose.yml` はパブリックリポジトリの raw URL から curl で取得（S3 不要）
- インスタンス ID は `Name=v-kara-public` タグで動的に取得するため `EC2_INSTANCE_ID` Secret は不要
- EC2 `user_data` を Ubuntu 向けに修正・SSM Agent インストールを追加（EC2 再作成時に自動セットアップ）

## Test plan

- [ ] マージ後、develop へのプッシュで GitHub Actions が成功することを確認
- [ ] SSM Fleet Manager でインスタンスが Online であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)