### PR TITLE
fix: EC2メモリ不足によるインスタンスダウンへの対策

### DIFF
--- a/ec2-docker-compose.yml
+++ b/ec2-docker-compose.yml
@@ -14,6 +14,7 @@ services:
   api:
     image: ${ECR_REGISTRY}/${ECR_API_REPO}:latest
     container_name: v-kara-api
+    restart: always
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE
       - DEPLOY_DB_ENV=EC2
@@ -28,6 +29,7 @@ services:
   app:
     image: ${ECR_REGISTRY}/${ECR_APP_REPO}:latest
     container_name: v-kara-app
+    restart: always
     env_file: app.env
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE

--- a/ec2-docker-compose.yml
+++ b/ec2-docker-compose.yml
@@ -14,7 +14,7 @@ services:
   api:
     image: ${ECR_REGISTRY}/${ECR_API_REPO}:latest
     container_name: v-kara-api
-    restart: always
+    restart: unless-stopped # always だと手動 docker stop 後も再起動してしまうため
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE
       - DEPLOY_DB_ENV=EC2
@@ -29,7 +29,7 @@ services:
   app:
     image: ${ECR_REGISTRY}/${ECR_APP_REPO}:latest
     container_name: v-kara-app
-    restart: always
+    restart: unless-stopped # always だと手動 docker stop 後も再起動してしまうため
     env_file: app.env
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -92,6 +92,7 @@ resource "aws_instance" "app" {
     dpkg-reconfigure -f noninteractive unattended-upgrades
 
     # Swap 1.5GB（t3a.micro RAM 1GB のメモリ不足対策）
+    set -e
     if ! swapon --show | grep -q /swapfile; then
       dd if=/dev/zero of=/swapfile bs=1M count=1536
       chmod 600 /swapfile

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -90,6 +90,15 @@ resource "aws_instance" "app" {
     # セキュリティパッチ自動適用（Ubuntu 向け）
     apt-get update -y && apt-get install -y unattended-upgrades
     dpkg-reconfigure -f noninteractive unattended-upgrades
+
+    # Swap 1.5GB（t3a.micro RAM 1GB のメモリ不足対策）
+    if ! swapon --show | grep -q /swapfile; then
+      dd if=/dev/zero of=/swapfile bs=1M count=1536
+      chmod 600 /swapfile
+      mkswap /swapfile
+      swapon /swapfile
+      echo '/swapfile none swap sw 0 0' >> /etc/fstab
+    fi
   EOF
 
   lifecycle {

--- a/scripts/ec2/setup_swap.sh
+++ b/scripts/ec2/setup_swap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# t3a.micro (RAM 1GB) のメモリ不足対策として 2GB の swap を作成する
+# t3a.micro (RAM 1GB) のメモリ不足対策として 1.5GB の swap を作成する
 # 既存インスタンスへの適用用スクリプト（新規インスタンスは user_data で自動適用される）
 set -e
 

--- a/scripts/ec2/setup_swap.sh
+++ b/scripts/ec2/setup_swap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# t3a.micro (RAM 1GB) のメモリ不足対策として 2GB の swap を作成する
+# 既存インスタンスへの適用用スクリプト（新規インスタンスは user_data で自動適用される）
+set -e
+
+SWAPFILE=/swapfile
+SWAP_SIZE_MB=1536
+
+if swapon --show | grep -q "$SWAPFILE"; then
+  echo "Swap already enabled at $SWAPFILE. Skipping."
+  exit 0
+fi
+
+echo "Creating 1.5GB swap at $SWAPFILE..."
+sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MB"
+sudo chmod 600 "$SWAPFILE"
+sudo mkswap "$SWAPFILE"
+sudo swapon "$SWAPFILE"
+
+if ! grep -q "$SWAPFILE" /etc/fstab; then
+  echo "$SWAPFILE none swap sw 0 0" | sudo tee -a /etc/fstab
+fi
+
+echo "Swap setup complete."
+free -h


### PR DESCRIPTION
- close #354

## 概要

EC2 (t3a.micro / RAM 1GB) が起動時にメモリ不足でダウンする問題への対策。

`journalctl` でインスタンス停止直前のログを確認したところ、メモリ枯渇によるキャッシュ強制解放が繰り返し発生していた。

## 変更内容

- `ec2-docker-compose.yml`: api/app コンテナに `restart: always` を追加
  - コンテナがクラッシュした際に自動で再起動されるようになる
- `infra/terraform/ec2.tf`: user_data に swap 1.5GB 設定を追加
  - 新規インスタンス作成時に自動で swap が設定される
- `scripts/ec2/setup_swap.sh`: 既存インスタンスへの swap 手動適用スクリプトを追加

## 既存インスタンスへの適用

マージ後、EC2 に SSH で入って以下を実行:

```bash
bash /home/ubuntu/v-kara/scripts/ec2/setup_swap.sh
```

## Test plan

- [ ] `setup_swap.sh` を EC2 上で実行し `free -h` で `Swap: 1.5Gi` が表示されることを確認
- [ ] しばらく運用してインスタンスが安定していることを確認