### PR TITLE
fix: Next.js standalone ビルドで next モジュールが見つからない問題を修正

### DIFF
--- a/ec2-docker-compose.yml
+++ b/ec2-docker-compose.yml
@@ -14,6 +14,7 @@ services:
   api:
     image: ${ECR_REGISTRY}/${ECR_API_REPO}:latest
     container_name: v-kara-api
+    restart: always
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE
       - DEPLOY_DB_ENV=EC2
@@ -28,6 +29,7 @@ services:
   app:
     image: ${ECR_REGISTRY}/${ECR_APP_REPO}:latest
     container_name: v-kara-app
+    restart: always
     env_file: app.env
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE

--- a/ec2-docker-compose.yml
+++ b/ec2-docker-compose.yml
@@ -14,7 +14,7 @@ services:
   api:
     image: ${ECR_REGISTRY}/${ECR_API_REPO}:latest
     container_name: v-kara-api
-    restart: always
+    restart: unless-stopped # always だと手動 docker stop 後も再起動してしまうため
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE
       - DEPLOY_DB_ENV=EC2
@@ -29,7 +29,7 @@ services:
   app:
     image: ${ECR_REGISTRY}/${ECR_APP_REPO}:latest
     container_name: v-kara-app
-    restart: always
+    restart: unless-stopped # always だと手動 docker stop 後も再起動してしまうため
     env_file: app.env
     environment:
       - DEPLOY_ENV=EC2_DOCKER_COMPOSE

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -92,6 +92,7 @@ resource "aws_instance" "app" {
     dpkg-reconfigure -f noninteractive unattended-upgrades
 
     # Swap 1.5GB（t3a.micro RAM 1GB のメモリ不足対策）
+    set -e
     if ! swapon --show | grep -q /swapfile; then
       dd if=/dev/zero of=/swapfile bs=1M count=1536
       chmod 600 /swapfile

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -90,6 +90,15 @@ resource "aws_instance" "app" {
     # セキュリティパッチ自動適用（Ubuntu 向け）
     apt-get update -y && apt-get install -y unattended-upgrades
     dpkg-reconfigure -f noninteractive unattended-upgrades
+
+    # Swap 1.5GB（t3a.micro RAM 1GB のメモリ不足対策）
+    if ! swapon --show | grep -q /swapfile; then
+      dd if=/dev/zero of=/swapfile bs=1M count=1536
+      chmod 600 /swapfile
+      mkswap /swapfile
+      swapon /swapfile
+      echo '/swapfile none swap sw 0 0' >> /etc/fstab
+    fi
   EOF
 
   lifecycle {

--- a/scripts/ec2/setup_swap.sh
+++ b/scripts/ec2/setup_swap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# t3a.micro (RAM 1GB) のメモリ不足対策として 2GB の swap を作成する
+# t3a.micro (RAM 1GB) のメモリ不足対策として 1.5GB の swap を作成する
 # 既存インスタンスへの適用用スクリプト（新規インスタンスは user_data で自動適用される）
 set -e
 

--- a/scripts/ec2/setup_swap.sh
+++ b/scripts/ec2/setup_swap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# t3a.micro (RAM 1GB) のメモリ不足対策として 2GB の swap を作成する
+# 既存インスタンスへの適用用スクリプト（新規インスタンスは user_data で自動適用される）
+set -e
+
+SWAPFILE=/swapfile
+SWAP_SIZE_MB=1536
+
+if swapon --show | grep -q "$SWAPFILE"; then
+  echo "Swap already enabled at $SWAPFILE. Skipping."
+  exit 0
+fi
+
+echo "Creating 1.5GB swap at $SWAPFILE..."
+sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MB"
+sudo chmod 600 "$SWAPFILE"
+sudo mkswap "$SWAPFILE"
+sudo swapon "$SWAPFILE"
+
+if ! grep -q "$SWAPFILE" /etc/fstab; then
+  echo "$SWAPFILE none swap sw 0 0" | sudo tee -a /etc/fstab
+fi
+
+echo "Swap setup complete."
+free -h

--- a/t0016Next/Dockerfile
+++ b/t0016Next/Dockerfile
@@ -4,7 +4,7 @@ FROM node:18-alpine AS base
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
-WORKDIR /app
+WORKDIR /app/myapp
 
 # Install dependencies based on the preferred package manager
 COPY myapp/package*.json ./
@@ -13,7 +13,7 @@ RUN npm ci;
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/myapp/node_modules ./myapp/node_modules
 COPY . .
 
 


### PR DESCRIPTION
## 概要

EC2 上で `v-kara-app` コンテナが `Cannot find module 'next'` でクラッシュし続ける問題を修正。

## 原因

`deps` ステージの `WORKDIR` が `/app` になっており、`npm ci` で生成される `node_modules` が `/app/node_modules/`（プロジェクト `/app/myapp/` の親ディレクトリ）に置かれていた。

Next.js の standalone ビルドはファイルトレーシングでプロジェクトディレクトリ配下の `node_modules` を収集するが、親ディレクトリの `node_modules` はトレースしない。そのため `next` パッケージが standalone 出力に含まれず、ランタイムで `Cannot find module 'next'` エラーが発生していた。

## 変更内容

`t0016Next/Dockerfile`:
- `deps` ステージの `WORKDIR` を `/app` → `/app/myapp` に変更
- `node_modules` が `/app/myapp/node_modules/` に生成されるようになり、standalone ビルドが正しくトレースできる

## Test plan

- [ ] Build & Push to ECR が成功する
- [ ] Deploy to EC2 のヘルスチェックが通る
- [ ] `curl http://localhost:80` が EC2 上で応答する