### PR TITLE
fix: Next.js standalone ビルドで next モジュールが見つからない問題を修正

### DIFF
--- a/t0016Next/Dockerfile
+++ b/t0016Next/Dockerfile
@@ -4,7 +4,7 @@ FROM node:18-alpine AS base
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
-WORKDIR /app
+WORKDIR /app/myapp
 
 # Install dependencies based on the preferred package manager
 COPY myapp/package*.json ./
@@ -13,7 +13,7 @@ RUN npm ci;
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/myapp/node_modules ./myapp/node_modules
 COPY . .
 
 


### PR DESCRIPTION
## 概要

EC2 上で `v-kara-app` コンテナが `Cannot find module 'next'` でクラッシュし続ける問題を修正。

## 原因

`deps` ステージの `WORKDIR` が `/app` になっており、`npm ci` で生成される `node_modules` が `/app/node_modules/`（プロジェクト `/app/myapp/` の親ディレクトリ）に置かれていた。

Next.js の standalone ビルドはファイルトレーシングでプロジェクトディレクトリ配下の `node_modules` を収集するが、親ディレクトリの `node_modules` はトレースしない。そのため `next` パッケージが standalone 出力に含まれず、ランタイムで `Cannot find module 'next'` エラーが発生していた。

## 変更内容

`t0016Next/Dockerfile`:
- `deps` ステージの `WORKDIR` を `/app` → `/app/myapp` に変更
- `node_modules` が `/app/myapp/node_modules/` に生成されるようになり、standalone ビルドが正しくトレースできる

## Test plan

- [ ] Build & Push to ECR が成功する
- [ ] Deploy to EC2 のヘルスチェックが通る
- [ ] `curl http://localhost:80` が EC2 上で応答する