### PR TITLE
feat: 手動デプロイワークフローを追加

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,200 @@
+name: Manual Deploy to EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      services:
+        description: 'デプロイするサービス'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - api
+          - app
+
+env:
+  AWS_REGION: ap-northeast-1
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build-api:
+    name: Build & Push API to ECR
+    runs-on: ubuntu-latest
+    if: inputs.services == 'both' || inputs.services == 'api'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push API image
+        run: |
+          docker build \
+            -t $ECR_REGISTRY/${{ secrets.ECR_API_REPO }}:latest \
+            -t $ECR_REGISTRY/${{ secrets.ECR_API_REPO }}:${{ github.sha }} \
+            ./t0016Go
+          docker push $ECR_REGISTRY/${{ secrets.ECR_API_REPO }}:latest
+          docker push $ECR_REGISTRY/${{ secrets.ECR_API_REPO }}:${{ github.sha }}
+
+  build-app:
+    name: Build & Push App to ECR
+    runs-on: ubuntu-latest
+    if: inputs.services == 'both' || inputs.services == 'app'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push App image
+        run: |
+          docker build \
+            -t $ECR_REGISTRY/${{ secrets.ECR_APP_REPO }}:latest \
+            -t $ECR_REGISTRY/${{ secrets.ECR_APP_REPO }}:${{ github.sha }} \
+            ./t0016Next
+          docker push $ECR_REGISTRY/${{ secrets.ECR_APP_REPO }}:latest
+          docker push $ECR_REGISTRY/${{ secrets.ECR_APP_REPO }}:${{ github.sha }}
+
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    needs: [build-api, build-app]
+    if: |
+      always() &&
+      (needs.build-api.result == 'success' || needs.build-api.result == 'skipped') &&
+      (needs.build-app.result == 'success' || needs.build-app.result == 'skipped') &&
+      (needs.build-api.result == 'success' || needs.build-app.result == 'success')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get EC2 Instance ID
+        id: get_instance
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=v-kara-public" \
+                      "Name=instance-state-name,Values=running" \
+            --query "Reservations[0].Instances[0].InstanceId" \
+            --output text)
+          echo "Instance ID: $INSTANCE_ID"
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
+
+      - name: Pull and restart containers on EC2
+        run: |
+          INSTANCE_ID="${{ steps.get_instance.outputs.instance_id }}"
+          SERVICES="${{ inputs.services }}"
+
+          if [ "$SERVICES" = "both" ]; then
+            PULL_SERVICES="api app"
+          else
+            PULL_SERVICES="$SERVICES"
+          fi
+          RESTART_SERVICES="$PULL_SERVICES"
+
+          echo "Services to pull: $PULL_SERVICES"
+          echo "Services to restart: $RESTART_SERVICES"
+
+          ECR_ENV="ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com ECR_API_REPO=${{ secrets.ECR_API_REPO }} ECR_APP_REPO=${{ secrets.ECR_APP_REPO }}"
+
+          cat > /tmp/ssm-deploy.json << ENDJSON
+          {
+            "InstanceIds": ["$INSTANCE_ID"],
+            "DocumentName": "AWS-RunShellScript",
+            "TimeoutSeconds": 600,
+            "Parameters": {
+              "commands": [
+                "set -e",
+                "mkdir -p /home/ubuntu/v-kara",
+                "curl -fsSL https://raw.githubusercontent.com/shari-sushi/V-Kara-Lists/${{ github.sha }}/ec2-docker-compose.yml -o /home/ubuntu/v-kara/ec2-docker-compose.yml",
+                "aws s3 cp s3://${{ secrets.S3_APP_ENV_BUCKET }}/.env /home/ubuntu/v-kara/app.env",
+                "aws s3 cp s3://${{ secrets.S3_API_ENV_BUCKET }}/.env /home/ubuntu/v-kara/api.env",
+                "chmod 600 /home/ubuntu/v-kara/*.env",
+                "aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com",
+                "$ECR_ENV docker compose -f /home/ubuntu/v-kara/ec2-docker-compose.yml pull $PULL_SERVICES",
+                "$ECR_ENV docker compose -f /home/ubuntu/v-kara/ec2-docker-compose.yml up -d --force-recreate $RESTART_SERVICES",
+                "rm -f /home/ubuntu/v-kara/api.env /home/ubuntu/v-kara/app.env"
+              ]
+            }
+          }
+          ENDJSON
+
+          COMMAND_ID=$(aws ssm send-command \
+            --cli-input-json file:///tmp/ssm-deploy.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+          for i in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "Status" --output text 2>/dev/null || echo "InProgress")
+            echo "[$i/60] Status: $STATUS"
+            [ "$STATUS" = "Success" ] && break
+            if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ] || [ "$STATUS" = "Cancelled" ]; then
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "$INSTANCE_ID" \
+                --query "StandardErrorContent" --output text
+              exit 1
+            fi
+            sleep 10
+          done
+          [ "$STATUS" = "Success" ] || { echo "SSM command timed out after 10 minutes"; exit 1; }
+
+      - name: Health check
+        run: |
+          INSTANCE_ID="${{ steps.get_instance.outputs.instance_id }}"
+
+          cat > /tmp/ssm-healthcheck.json << 'ENDJSON'
+          {
+            "InstanceIds": ["INSTANCE_ID_PLACEHOLDER"],
+            "DocumentName": "AWS-RunShellScript",
+            "TimeoutSeconds": 120,
+            "Parameters": {
+              "commands": [
+                "for i in $(seq 1 12); do curl -sf http://localhost:8080/health && break || { [ \"$i\" -eq 12 ] && exit 1 || sleep 5; }; done",
+                "for i in $(seq 1 12); do curl -sf http://localhost/user/signin && break || { [ \"$i\" -eq 12 ] && exit 1 || sleep 5; }; done"
+              ]
+            }
+          }
+          ENDJSON
+          sed -i "s/INSTANCE_ID_PLACEHOLDER/$INSTANCE_ID/" /tmp/ssm-healthcheck.json
+
+          COMMAND_ID=$(aws ssm send-command \
+            --cli-input-json file:///tmp/ssm-healthcheck.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$INSTANCE_ID"
+
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$INSTANCE_ID" \
+            --query "StandardOutputContent" \
+            --output text


### PR DESCRIPTION
## Summary

- GitHub Actions の UI から手動でビルド・ECR送信・EC2デプロイを実行できる `manual-deploy.yml` を追加
- デプロイ対象サービスを `api` / `app` / `both` から選択可能
- SSMコマンドは既存の `deploy.yml` と同様の修正済み構成（`set -e` + 絶対パス）を採用

## 使い方

GitHub → Actions → **Manual Deploy to EC2** → Run workflow → サービスを選択して実行

## Test plan

- [ ] Actionsタブで `Manual Deploy to EC2` が表示されること
- [ ] `both` を選択して実行し、api・app両方がデプロイされること
- [ ] `api` / `app` 単体でも正常にデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)