### PR TITLE
fix: 「動画を固定」OFF時のページ下部の空白を修正

### DIFF
--- a/VIBES/done/20260520-1-フッタースペース動的制御.md
+++ b/VIBES/done/20260520-1-フッタースペース動的制御.md
@@ -1,0 +1,48 @@
+# フッタースペース動的制御
+
+## 背景・目的
+
+Issue #364: topページや登録ページの下部に謎の空間がある。
+
+`Footer` コンポーネントが「動画を固定」のON/OFFに関わらず常に `height: 200` のスペースを確保しているため、
+動画プレーヤーが固定されていないときでも下部に無駄な空白が発生している。
+
+## 変更スコープ
+
+- `t0016Next/myapp/src/components/layout/Layout.tsx`
+  - `Footer` コンポーネントに `useVideo()` を追加し、`position === "footer"` の時だけスペースを確保する
+
+## 実装ステップ
+
+1. `Footer` コンポーネント（`Layout.tsx:192-195`）を修正する
+   - `useVideo()` で `videoState.position` を取得する
+   - `position === "footer"` のときのみ `height: 200` の div を返す
+   - それ以外は `null` を返す
+
+## 変更前後のイメージ
+
+```tsx
+// Before: 常にスペースを確保
+const Footer = () => {
+  return <div style={{ height: 200 }} />
+}
+
+// After: footerポジション時のみスペースを確保
+const Footer = () => {
+  const { videoState } = useVideo()
+  if (videoState.position !== "footer") return null
+  return <div style={{ height: 200 }} />
+}
+```
+
+## 完了条件
+
+- [ ] 「動画を固定」OFF時にページ下部の空白がなくなること
+- [ ] 「動画を固定」ON時は従来通り200pxのスペースが確保されること
+- [ ] `npm run build` が型エラーなしで通ること
+- [ ] `npm run lint` が通ること
+
+## 注意事項
+
+- `Footer` は `Layout` コンポーネント内のローカル関数なので影響範囲は局所的
+- `VideoLayout.tsx` の外側 `<div>` は今回触らない（スペースには影響しない）

--- a/t0016Next/myapp/src/components/layout/Layout.tsx
+++ b/t0016Next/myapp/src/components/layout/Layout.tsx
@@ -190,7 +190,8 @@ const Header = () => {
 }
 
 const Footer = () => {
-  // videoPlayer用のスペース。videoStateで管理して動的にしたい
+  const { videoState } = useVideo()
+  if (videoState.position !== "footer") return null
   return <div style={{ height: 200 }} />
 }
 


### PR DESCRIPTION
- close #364

## Summary

- `Footer` コンポーネントが `videoState.position` に関わらず常に `height: 200` のスペースを確保していた
- `position === "footer"`（動画を固定ON）の時のみスペースを確保するよう修正

## 変更箇所

`t0016Next/myapp/src/components/layout/Layout.tsx`

```tsx
// Before
const Footer = () => {
  return <div style={{ height: 200 }} />
}

// After
const Footer = () => {
  const { videoState } = useVideo()
  if (videoState.position !== "footer") return null
  return <div style={{ height: 200 }} />
}
```

## Test plan

- [ ] 「動画を固定」OFF（初期状態）でページ下部の空白がなくなること
- [ ] 「動画を固定」ONにすると 200px のスペースが確保されること（プレーヤーの下にコンテンツが隠れない）
- [ ] top ページ・登録ページ等で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)