### PR TITLE
fix: Goサーバー起動安定化（gin.Recovery()明示化・DB接続リトライ追加）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ Public Repositoryなのでセキュリティリスクとなる機密情報のハ
 
 ## vibeコーディングの進め方
 
-1. 実装前に `VIBES/plan/` に計画ファイルを作成する
+1. 実装前に `VIBES/plan/` に計画ファイルを作成し、実装後はVIBES/doneに計画ファイルを移動する
 2. ユーザーと仕様を合意してから実装を開始する
 3. 実装後は lint / build が通ることを確認する
 4. コミット前に型エラーがないことを確認する
+5. githubへのpr, コメントは文末に `🤖 Generated with [Claude Code](https://claude.com/claude-code)`を記載する

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ V-karaはVTuberの歌枠の歌情報を登録し、いつでも見返せるweb�
 ### 基本機能
 
 - 登録されたデータの一覧、検索<br/>
-- １クリックで動画や歌を視聴<br/> <img width="700" height="1107" alt="image" src="https://github.com/user-attachments/assets/7943acdd-f7fb-4238-bdf6-f5fad3c6cc88" /><br/>
-- Vtuber、歌枠(動画)、その中で歌っている歌の登録<br/> <img width="700" height="891" alt="image" src="https://github.com/user-attachments/assets/e1637531-477f-4c40-9a88-f7aa3469de39" /><br/>
+- １クリックで動画や歌を視聴<br/> <img width="700" alt="v-karaのtopページ" src="https://github.com/user-attachments/assets/7943acdd-f7fb-4238-bdf6-f5fad3c6cc88" /><br/>
+- Vtuber、歌枠(動画)、その中で歌っている歌の登録<br/> <img width="700" alt="v-karaのコンテンツ登録ページ" src="https://github.com/user-attachments/assets/e1637531-477f-4c40-9a88-f7aa3469de39" /><br/>
 
 ### 補助機能
 

--- a/t0016Go/cmd/main.go
+++ b/t0016Go/cmd/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/sharin-sushi/0016go_next_relation/infra"
 	"github.com/sharin-sushi/0016go_next_relation/common"
+	"github.com/sharin-sushi/0016go_next_relation/infra"
 )
 
 func init() {
@@ -17,7 +17,8 @@ func init() {
 }
 
 func main() {
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.Recovery())
 
 	AllowOrigins := []string{}
 	if common.IsOnLocal {
@@ -45,6 +46,8 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{})
 	})
 
+	// /healthより後に呼び出すことで意図的にhealthチェックログ残さない
+	// awsのhealthチェックが頻繁でそれだけでログが埋まるのを防止するため
 	r.Use(requestLogger())
 
 	infra.Routing(r)

--- a/t0016Go/handler/content/dummy_top_page.go
+++ b/t0016Go/handler/content/dummy_top_page.go
@@ -9,7 +9,7 @@ import (
 
 // 手動でmerge, buildしてる限りは、apiをbuildし直す日時をメモする（たまに忘れる）
 // 曲名１文字対応、等
-const LastUpdateData = "2024/01/14 3時 fix:歌複数登録要のapiを追加"
+const LastUpdateData = "2026/05/20 panicでgoサーバーが落ちないように / 「動画を固定」OFF時のフッタースペースを削除"
 
 func (h *ContentHandler) ReturnDummyTopPage(c *gin.Context) {
 	h.returnTestPage(c)

--- a/t0016Go/infra/db.go
+++ b/t0016Go/infra/db.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"fmt"
 	"os"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
@@ -102,18 +103,26 @@ func dbInit() repository.SqlHandler {
 
 	fmt.Printf("path=%v \n", path)
 	var err error
-	var sqlHandler *SqlHandler
-	gormDB, err := gorm.Open(mysql.Open(path), &gorm.Config{})
+	var gormDB *gorm.DB
+	waitSec := 1
+	for i := 0; i < 7; i++ {
+		gormDB, err = gorm.Open(mysql.Open(path), &gorm.Config{})
+		if err == nil {
+			break
+		}
+		if i == 6 {
+			panic("failed to connect database after retries")
+		}
+		fmt.Printf("DB接続失敗。%d秒後にリトライ (%d/6)\n", waitSec, i+1)
+		time.Sleep(time.Duration(waitSec) * time.Second)
+		waitSec *= 2
+	}
 	if !common.IsOnCloud {
 		gormDB = gormDB.Debug()
 	}
-	if err == nil {
-		sqlHandler = new(SqlHandler)
-		sqlHandler.Conn = gormDB
-		sqlHandler.migration()
-	} else {
-		panic("failed to connect database")
-	}
+	sqlHandler := new(SqlHandler)
+	sqlHandler.Conn = gormDB
+	sqlHandler.migration()
 
 	return sqlHandler
 }


### PR DESCRIPTION
- #292

## Summary

### gin.Default() → gin.New() + gin.Recovery()
- `gin.Default()` が内包する `gin.Logger()` を外し、カスタムの `requestLogger()` のみ使用するよう変更
- `requestLogger()` を `/health` エンドポイント登録の**後**に配置することで、AWSヘルスチェックのアクセスログを意図的に除外
  - ヘルスチェックが頻繁にあるためそれだけでログが埋まるのを防止

### DB接続のエクスポネンシャルバックオフリトライ
- 起動時にDB接続が失敗した場合、即panicではなく最大約63秒リトライするよう変更
- 待機間隔: 1s → 2s → 4s → 8s → 16s → 32s（6回リトライ後にpanic）
- docker-compose起動時などDBの準備が遅れるケースで即落ちしなくなる

## おまけ
- README: 画像のalt属性をアクセシビリティ改善
- CLAUDE.md: 完了した計画書をVIBES/doneへ移動するルール追加 / PR・コメントへのClaude Code表記ルール追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)