### PR TITLE
fix: Dockerfile ベースイメージを node:18-alpine から node:18-slim に変更

### DIFF
--- a/t0016Next/Dockerfile
+++ b/t0016Next/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:18-alpine AS base
+FROM node:18-slim AS base
 
 # Install dependencies only when needed
 FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
 WORKDIR /app/myapp
 
 # Install dependencies based on the preferred package manager


### PR DESCRIPTION
## Summary

- `node:18-alpine` (musl libc) では `fcntl64` シンボルが存在せず、esbuild 等の glibc コンパイル済みバイナリが `npm ci` 時に失敗する問題を修正
- ベースイメージを `node:18-slim` (Debian, glibc) に変更
- Alpine 専用の `libc6-compat` インストール行も不要のため削除

## Test plan

- [ ] CI の `Build & Push App to ECR` が通ること
- [ ] `npm ci` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

```bash
Merge pull request #373 from shari-sushi/feature/371-storybook #21

1 error and 1 warning
Build & Push App to ECR
failed 16 hours ago in 1m 3s

Run docker build \
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2.02kB 0.0s done
#1 DONE 0.0s

#2 [auth] library/node:pull token for registry-1.docker.io
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/node:18-alpine
#3 DONE 0.7s

#4 [internal] load .dockerignore
#4 transferring context: 57B done
#4 DONE 0.0s

#5 [internal] load build context
#5 transferring context: 1.05MB 0.0s done
#5 DONE 0.0s

#6 [base 1/1] FROM docker.io/library/node:18-alpine@sha256:8d6421d663b4c28fd3ebc498332f249011d118945588d0a35cb9bc4b8ca09d9e
#6 resolve docker.io/library/node:18-alpine@sha256:8d6421d663b4c28fd3ebc498332f249011d118945588d0a35cb9bc4b8ca09d9e done
#6 sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 0B / 3.64MB 0.1s
#6 sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e 0B / 40.01MB 0.1s
#6 sha256:1e5a4c89cee5c0826c540ab06d4b6b491c96eda01837f430bd47f0d26702d6e3 0B / 1.26MB 0.1s
#6 sha256:8d6421d663b4c28fd3ebc498332f249011d118945588d0a35cb9bc4b8ca09d9e 7.67kB / 7.67kB done
#6 sha256:929b04d7c782f04f615cf785488fed452b6569f87c73ff666ad553a7554f0006 1.72kB / 1.72kB done
#6 sha256:ee77c6cd7c1886ecc802ad6cedef3a8ec1ea27d1fb96162bf03dd3710839b8da 6.18kB / 6.18kB done
#6 sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e 2.10MB / 40.01MB 0.2s
#6 extracting sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870
#6 sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 3.64MB / 3.64MB 0.3s done
#6 sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e 29.36MB / 40.01MB 0.3s
#6 sha256:1e5a4c89cee5c0826c540ab06d4b6b491c96eda01837f430bd47f0d26702d6e3 1.26MB / 1.26MB 0.2s done
#6 extracting sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 0.1s done
#6 sha256:25ff2da83641908f65c3a74d80409d6b1b62ccfaab220b9ea70b80df5a2e0549 0B / 446B 0.3s
#6 extracting sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e
#6 sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e 40.01MB / 40.01MB 0.3s done
#6 sha256:25ff2da83641908f65c3a74d80409d6b1b62ccfaab220b9ea70b80df5a2e0549 446B / 446B 0.3s done
#6 extracting sha256:dd71dde834b5c203d162902e6b8994cb2309ae049a0eabc4efea161b2b5a3d0e 1.0s done
#6 extracting sha256:1e5a4c89cee5c0826c540ab06d4b6b491c96eda01837f430bd47f0d26702d6e3
#6 extracting sha256:1e5a4c89cee5c0826c540ab06d4b6b491c96eda01837f430bd47f0d26702d6e3 0.0s done
#6 extracting sha256:25ff2da83641908f65c3a74d80409d6b1b62ccfaab220b9ea70b80df5a2e0549 done
#6 DONE 1.6s

#7 [builder 1/4] WORKDIR /app
#7 DONE 0.0s

#8 [runner 2/8] RUN addgroup --system --gid 1001 nodejs
#8 DONE 0.2s

#9 [deps 1/4] RUN apk add --no-cache libc6-compat
#9 ...

#10 [runner 3/8] RUN adduser --system --uid 1001 nextjs
#10 DONE 0.1s

#9 [deps 1/4] RUN apk add --no-cache libc6-compat
#9 0.181 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
#9 0.478 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
#9 0.916 (1/3) Installing musl-obstack (1.2.3-r2)
#9 0.931 (2/3) Installing libucontext (1.3.2-r0)
#9 0.946 (3/3) Installing gcompat (1.1.0-r4)
#9 0.963 OK: 10 MiB in 20 packages
#9 DONE 1.0s

#11 [deps 2/4] WORKDIR /app/myapp
#11 DONE 0.0s

#12 [deps 3/4] COPY myapp/package*.json ./
#12 DONE 0.0s

#13 [deps 4/4] RUN npm ci;
#13 5.359 npm warn deprecated @types/react-select@5.0.1: This is a stub types definition. react-select provides its own type definitions, so you do not need this installed.
#13 5.402 npm warn deprecated @types/axios@0.14.0: This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!
#13 7.818 npm warn deprecated uuid@9.0.1: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
#13 28.02 npm error code 127
#13 28.02 npm error path /app/myapp/node_modules/esbuild
#13 28.02 npm error command failed
#13 28.02 npm error command sh -c node install.js
#13 28.02 npm error Error relocating /app/myapp/node_modules/node/bin/node: fcntl64: symbol not found
#13 28.02 npm notice
#13 28.02 npm notice New major version of npm available! 10.8.2 -> 11.14.1
#13 28.02 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.14.1
#13 28.02 npm notice To update run: npm install -g npm@11.14.1
#13 28.02 npm notice
#13 28.02 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-05-20T17_43_12_547Z-debug-0.log
#13 ERROR: process "/bin/sh -c npm ci;" did not complete successfully: exit code: 127
------
 > [deps 4/4] RUN npm ci;:
28.02 npm error path /app/myapp/node_modules/esbuild
28.02 npm error command failed
28.02 npm error command sh -c node install.js
28.02 npm error Error relocating /app/myapp/node_modules/node/bin/node: fcntl64: symbol not found
28.02 npm notice
28.02 npm notice New major version of npm available! 10.8.2 -> 11.14.1
28.02 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.14.1
28.02 npm notice To update run: npm install -g npm@11.14.1
28.02 npm notice
28.02 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-05-20T17_43_12_547Z-debug-0.log
------
Dockerfile:11
--------------------
   9 |     # Install dependencies based on the preferred package manager
  10 |     COPY myapp/package*.json ./
  11 | >>> RUN npm ci;
  12 |     
  13 |     # Rebuild the source code only when needed
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c npm ci;" did not complete successfully: exit code: 127
Error: Process completed with exit code 1.

```