### PR TITLE
feat: CI を app / api で分ける

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,14 +1,21 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+name: API (Go)
 
-name: Go
-
-on: 
+on:
   push:
     branches: ["*"]
+    paths:
+      - 't0016Go/**'
+      - 'docker-compose*.yml'
+      - 'ec2-docker-compose.yml'
+      - '.github/workflows/**'
   pull_request:
-    branches: [ "develop" ]
-  
+    branches: [develop]
+    paths:
+      - 't0016Go/**'
+      - 'docker-compose*.yml'
+      - 'ec2-docker-compose.yml'
+      - '.github/workflows/**'
+
 jobs:
 
   build:
@@ -21,12 +28,10 @@ jobs:
       with:
         go-version: '1.18'
 
-    # -v : パッケージ名を出力
     - name: Build
       run: go build -v ./...
       working-directory: t0016Go/.
 
-    # -v : テスト成功しても値を出力
     - name: Test
       run: go test -v ./...
       working-directory: t0016Go/.

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,43 @@
+name: App (Next.js)
+
+on:
+  push:
+    branches: ["*"]
+    paths:
+      - 't0016Next/**'
+      - 'docker-compose*.yml'
+      - 'ec2-docker-compose.yml'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [develop]
+    paths:
+      - 't0016Next/**'
+      - 'docker-compose*.yml'
+      - 'ec2-docker-compose.yml'
+      - '.github/workflows/**'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+        cache-dependency-path: t0016Next/myapp/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+      working-directory: t0016Next/myapp
+
+    - name: Build
+      run: npm run build
+      working-directory: t0016Next/myapp
+
+    - name: Lint
+      run: npm run lint
+      working-directory: t0016Next/myapp

--- a/VIBES/plan/20260521-1-CIをappとapiで分ける.md
+++ b/VIBES/plan/20260521-1-CIをappとapiで分ける.md
@@ -1,0 +1,31 @@
+# CIをappとapiで分ける
+
+## 背景・目的
+
+現状、`go.yml` がパスフィルタなしで全プッシュ時にGoビルドを実行していた。
+Next.jsのCIは存在しなかった。
+変更のあったサービスだけCIが走るよう、api/appそれぞれのワークフローに分割する。
+
+## 変更スコープ
+
+- `.github/workflows/go.yml` → 削除
+- `.github/workflows/api.yml` → 新規作成（Go CI、パスフィルタ付き）
+- `.github/workflows/app.yml` → 新規作成（Next.js CI、パスフィルタ付き）
+
+## 実装ステップ
+
+1. `api.yml` を作成（`go.yml` の内容 + パスフィルタ）
+2. `go.yml` を削除
+3. `app.yml` を新規作成（Node.js 18 + npm ci + build + lint）
+
+## 完了条件
+
+- [x] `t0016Go/**` のみ変更 → api CIのみ起動
+- [x] `t0016Next/**` のみ変更 → app CIのみ起動
+- [x] `docker-compose*.yml` 変更 → 両方起動
+- [x] `.github/workflows/**` 変更 → 両方起動
+
+## 注意事項
+
+- GORM の AutoMigrate 等、既存のGoテストが通ることを前提とする
+- Next.js の build は環境変数 `NEXT_PUBLIC_API_DOMAIN` が未設定でも通ること（ビルド時は不要）


### PR DESCRIPTION
- close #384

## 概要

GitHub Actions の CI ワークフローを app（Next.js）と api（Go）に分割。変更のあったサービスだけ CI が走るようにパスフィルタを設定する。

## 変更内容

- `.github/workflows/go.yml` → `api.yml` にリネームし、パスフィルタ（`t0016Go/**`・`docker-compose*.yml`・`.github/workflows/**`）を追加
- `.github/workflows/app.yml` 新規追加（Node.js 18 / npm ci / build / lint、同様のパスフィルタ付き）
- `VIBES/plan/20260521-1-CIをappとapiで分ける.md` 計画ファイル追加

## 動作

| 変更箇所 | api CI | app CI |
| --- | --- | --- |
| `t0016Go/**` のみ | ✅ 起動 | ⏭ スキップ |
| `t0016Next/**` のみ | ⏭ スキップ | ✅ 起動 |
| `docker-compose*.yml` | ✅ 起動 | ✅ 起動 |
| `.github/workflows/**` | ✅ 起動 | ✅ 起動 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)